### PR TITLE
Tokio not tokio core

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,5 +15,6 @@ commands = []
 [dependencies]
 bytes = "0.4.5"
 futures = "0.1.18"
+log = "0.4.1"
 tokio = "0.1.0"
 tokio-io = "0.1.5"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,3 +18,7 @@ futures = "0.1.18"
 log = "0.4.1"
 tokio = "0.1.0"
 tokio-io = "0.1.5"
+
+[dev-dependencies]
+env_logger = "0.5.3"
+futures-cpupool = "0.1.8"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "redis-async"
-version = "0.0.7"
+version = "0.1.0"
 authors = ["Ben Ashford <benashford@users.noreply.github.com>"]
 license = "MIT/Apache-2.0"
 readme = "README.md"
@@ -14,6 +14,6 @@ commands = []
 
 [dependencies]
 bytes = "0.4.5"
-futures = "0.1.16"
-tokio-core = "0.1.9"
-tokio-io = "0.1.3"
+futures = "0.1.18"
+tokio = "0.1.0"
+tokio-io = "0.1.5"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,5 +20,4 @@ tokio = "0.1.0"
 tokio-io = "0.1.5"
 
 [dev-dependencies]
-env_logger = "0.5.3"
 futures-cpupool = "0.1.8"

--- a/README.md
+++ b/README.md
@@ -7,11 +7,13 @@
 [![](https://docs.rs/redis-async/badge.svg)](https://docs.rs/redis-async/)
 [![Dependency Status](https://dependencyci.com/github/benashford/redis-async-rs/badge)](https://dependencyci.com/github/benashford/redis-async-rs)
 
-An exercise in learning Tokio and Rust's futures by creating a Redis client.  [Documentation](https://docs.rs/redis-async/)
+Using Tokio and Rust's futures to create an asynchronous Redis client.  [Documentation](https://docs.rs/redis-async/)
 
 ## Releases
 
-The API is currently low-level and still subject to change as not all edge-cases have been worked through yet.
+The API is currently low-level and still subject to change.
+
+Initially I'm focussing on single-server Redis instances, another long-term goal is to support Redis clusters.  This would make the implementation more complex as it requires routing, and handling error conditions such as `MOVED`.
 
 ## Other clients
 
@@ -19,12 +21,6 @@ There are a number of pre-existing Redis clients for Rust, two of particular int
 
 * Tokio-Redis - https://github.com/tokio-rs/tokio-redis - written as a demo of Tokio, by Tokio developers
 * Redis-RS - https://github.com/mitsuhiko/redis-rs - the most popular, but uses blocking I/O and isn't compatible with Tokio
-
-## Why a new Redis client?
-
-The primary goal is to teach myself Tokio.  With a longer-term goal of achieving more than the two existing Redis clients listed above.  For example, Tokio-Redis assumes that a Redis client receives one response to one request, which is true in most cases; however some Redis commands (e.g. the PUBSUB commands) result in infinite streams of data.  A fully-functional Redis client needs to handle such things.
-
-Initially I'm focussing on single-server Redis instances, another long-term goal is to support Redis clusters.  This would make the implementation more complex as it requires routing, and handling error conditions such as `MOVED`.
 
 ## Usage
 
@@ -60,58 +56,28 @@ In order to test this, a tool like ngrep can be used to monitor the data sent to
 interface: lo0 (127.0.0.0/255.0.0.0)
 filter: (ip or ip6) and ( port 6379 )
 #####
-T 127.0.0.1:54384 -> 127.0.0.1:6379 [AP]
-  *2..$4..INCR..$18..realistic_test_ctr..
+T 127.0.0.1:61112 -> 127.0.0.1:6379 [AP]
+  *2..$4..INCR..$18..realistic_test_ctr..*2..$4..INCR..$18..realistic_test_ctr..*2..$4..INCR..$18..
+  realistic_test_ctr..*2..$4..INCR..$18..realistic_test_ctr..*2..$4..INCR..$18..realistic_test_ctr.
+  .*2..$4..INCR..$18..realistic_test_ctr..*2..$4..INCR..$18..realistic_test_ctr..*2..$4..INCR..$18.
+  .realistic_test_ctr..*2..$4..INCR..$18..realistic_test_ctr..*2..$4..INCR..$18..realistic_test_ctr
+  ..
 ##
-T 127.0.0.1:54384 -> 127.0.0.1:6379 [AP]
-  *2..$4..INCR..$18..realistic_test_ctr..*2..$4..INCR..$18..realistic_test_ctr..*2..$4..INCR..$18.
-  .realistic_test_ctr..*2..$4..INCR..$18..realistic_test_ctr..*2..$4..INCR..$18..realistic_test_ct
-  r..*2..$4..INCR..$18..realistic_test_ctr..*2..$4..INCR..$18..realistic_test_ctr..*2..$4..INCR..$
-  18..realistic_test_ctr..*2..$4..INCR..$18..realistic_test_ctr..
+T 127.0.0.1:6379 -> 127.0.0.1:61112 [AP]
+  :1..:2..:3..:4..:5..:6..:7..:8..:9..:10..
 ##
-T 127.0.0.1:6379 -> 127.0.0.1:54384 [AP]
-  :3151..
+T 127.0.0.1:61112 -> 127.0.0.1:6379 [AP]
+  *3..$3..SET..$4..rt_1..$1..0..*3..$3..SET..$1..0..$4..rt_1..*3..$3..SET..$4..rt_2..$1..1..*3..$3.
+  .SET..$1..1..$4..rt_2..*3..$3..SET..$4..rt_3..$1..2..*3..$3..SET..$1..2..$4..rt_3..*3..$3..SET..$
+  4..rt_4..$1..3..*3..$3..SET..$1..3..$4..rt_4..*3..$3..SET..$4..rt_5..$1..4..*3..$3..SET..$1..4..$
+  4..rt_5..*3..$3..SET..$4..rt_6..$1..5..*3..$3..SET..$1..5..$4..rt_6..*3..$3..SET..$4..rt_7..$1..6
+  ..*3..$3..SET..$1..6..$4..rt_7..*3..$3..SET..$4..rt_8..$1..7..*3..$3..SET..$1..7..$4..rt_8..*3..$
+  3..SET..$4..rt_9..$1..8..*3..$3..SET..$1..8..$4..rt_9..*3..$3..SET..$5..rt_10..$1..9..*3..$3..SET
+  ..$1..9..$5..rt_10..
 ##
-T 127.0.0.1:6379 -> 127.0.0.1:54384 [AP]
-  :3152..:3153..:3154..:3155..:3156..:3157..:3158..:3159..:3160..
-##
-T 127.0.0.1:54384 -> 127.0.0.1:6379 [AP]
-  *3..$3..SET..$7..rt_3151..$1..0..
-##
-T 127.0.0.1:54384 -> 127.0.0.1:6379 [AP]
-  *3..$3..SET..$1..0..$7..rt_3151..*3..$3..SET..$7..rt_3152..$1..1..
-##
-T 127.0.0.1:54384 -> 127.0.0.1:6379 [AP]
-  *3..$3..SET..$1..1..$7..rt_3152..*3..$3..SET..$7..rt_3153..$1..2..*3..$3..SET..$1..2..$7..rt_315
-  3..
-##
-T 127.0.0.1:54384 -> 127.0.0.1:6379 [AP]
-  *3..$3..SET..$7..rt_3154..$1..3..*3..$3..SET..$1..3..$7..rt_3154..*3..$3..SET..$7..rt_3155..$1..
-  4..
-##
-T 127.0.0.1:54384 -> 127.0.0.1:6379 [AP]
-  *3..$3..SET..$1..4..$7..rt_3155..*3..$3..SET..$7..rt_3156..$1..5..*3..$3..SET..$1..5..$7..rt_315
-  6..
-##
-T 127.0.0.1:54384 -> 127.0.0.1:6379 [AP]
-  *3..$3..SET..$7..rt_3157..$1..6..*3..$3..SET..$1..6..$7..rt_3157..
-##
-T 127.0.0.1:54384 -> 127.0.0.1:6379 [AP]
-  *3..$3..SET..$7..rt_3158..$1..7..*3..$3..SET..$1..7..$7..rt_3158..*3..$3..SET..$7..rt_3159..$1..
-  8..
-#
-T 127.0.0.1:6379 -> 127.0.0.1:54384 [AP]
-  +OK..+OK..+OK..+OK..+OK..+OK..
-##
-T 127.0.0.1:54384 -> 127.0.0.1:6379 [AP]
-  *3..$3..SET..$1..8..$7..rt_3159..*3..$3..SET..$7..rt_3160..$1..9..*3..$3..SET..$1..9..$7..rt_316
-  0..
-##
-T 127.0.0.1:6379 -> 127.0.0.1:54384 [AP]
-  +OK..+OK..+OK..+OK..+OK..+OK..+OK..+OK..+OK..+OK..+OK..
-##
-T 127.0.0.1:6379 -> 127.0.0.1:54384 [AP]
-  +OK..+OK..+OK..
+T 127.0.0.1:6379 -> 127.0.0.1:61112 [AP]
+  +OK..+OK..+OK..+OK..+OK..+OK..+OK..+OK..+OK..+OK..+OK..+OK..+OK..+OK..+OK..+OK..+OK..+OK..+OK..+O
+  K..
 ```
 
 See note on 'Performance' for what impact this has.
@@ -136,10 +102,10 @@ The benchmarks are intended to be compatible with those of [redis-rs](https://gi
 
 In most cases the difference is small.
 
-| Benchmark        | redis-rs (the control)                                           | redis-async-rs  |
-| ---------------- | ---------------------------------------------------------------- | --------------- |
-| simple_getsetdel | 122,495 ns/iter (not pipelined)<br>47,767 ns/iter (pipelined)    | 56,321 ns/iter  |
-| complex          | 8,336,466 ns/iter (non pipelined)<br>527,535 ns/iter (pipelined) | 939,380 ns/iter |
+| Benchmark        | redis-rs (the control)                                            | redis-async-rs  |
+| ---------------- | ----------------------------------------------------------------- | --------------- |
+| simple_getsetdel | 132,856 ns/iter (not pipelined)<br>54,967 ns/iter (pipelined)     | 104,023 ns/iter |
+| complex          | 10,588,664 ns/iter (non pipelined)<br>695,551 ns/iter (pipelined) | 848,265 ns/iter |
 
 For `redis-rs` each benchmark has a pipelined and a non-pipelined version.  For `redis-async-rs` there is only one version as pipelining is handled implicitely.
 

--- a/benches/benchmarks.rs
+++ b/benches/benchmarks.rs
@@ -12,85 +12,128 @@
 
 extern crate test;
 
+extern crate env_logger;
 extern crate futures;
-extern crate tokio_core;
+extern crate futures_cpupool;
+
+#[macro_use]
+extern crate log;
+
+extern crate tokio;
 
 #[macro_use]
 extern crate redis_async;
 
+use std::net::SocketAddr;
 use std::sync::Arc;
 
 use test::Bencher;
 
 use futures::Future;
+use futures::future;
+use futures::future::Executor;
+use futures::sync::oneshot;
 
-use tokio_core::reactor::Core;
+use futures_cpupool::CpuPool;
+
+use tokio::executor::current_thread;
 
 use redis_async::client;
+use redis_async::resp;
+
+fn open_paired_connection(addr: &SocketAddr, cpu_pool: CpuPool) -> client::PairedConnection {
+    let rx = current_thread::run(move |_| {
+        let (tx, rx) = oneshot::channel();
+        let connection = client::paired_connect(addr, cpu_pool)
+            .map_err(|e| println!("Error opening connection: {}", e))
+            .and_then(|con| match tx.send(con) {
+                Ok(_) => future::ok(()),
+                Err(e) => future::err(()),
+            });
+        current_thread::spawn(connection);
+        rx
+    });
+    rx.wait().expect("Connection")
+}
 
 #[bench]
 fn bench_simple_getsetdel(b: &mut Bencher) {
-    let mut core = Core::new().unwrap();
+    let cpu_pool = CpuPool::new_num_cpus();
     let addr = "127.0.0.1:6379".parse().unwrap();
 
-    let connection = client::paired_connect(&addr, &core.handle());
-    let connection = core.run(connection).unwrap();
+    let connection = open_paired_connection(&addr, cpu_pool.clone());
 
     b.iter(|| {
-               faf!(connection.send(resp_array!["SET", "test_key", "42"]));
-               let get = connection.send(resp_array!["GET", "test_key"]);
-               let del = connection.send(resp_array!["DEL", "test_key"]);
-               let get_set = get.join(del);
-               let (_, _): (String, String) = core.run(get_set).unwrap();
-           });
-}
-
-#[bench]
-fn bench_big_pipeline(b: &mut Bencher) {
-    let mut core = Core::new().unwrap();
-    let addr = "127.0.0.1:6379".parse().unwrap();
-
-    let connection = client::paired_connect(&addr, &core.handle());
-    let connection = core.run(connection).unwrap();
-
-    let data_size = 100;
-
-    b.iter(|| {
-        for x in 0..data_size {
-            let test_key = format!("test_{}", x);
-            faf!(connection.send(resp_array!["SET", test_key, x.to_string()]));
-        }
-        let mut gets = Vec::with_capacity(data_size);
-        for x in 0..data_size {
-            let test_key = format!("test_{}", x);
-            gets.push(connection.send(resp_array!["GET", test_key]));
-        }
-        let last_get = gets.remove(data_size - 1);
-        let _: String = core.run(last_get).unwrap();
+        faf!(connection.send(resp_array!["SET", "test_key", "42"]));
+        let get = connection.send(resp_array!["GET", "test_key"]);
+        let del = connection.send(resp_array!["DEL", "test_key"]);
+        let get_set = get.join(del);
+        cpu_pool.execute(
+            get_set
+                .map(|(a, b): (resp::RespValue, resp::RespValue)| ())
+                .map_err(|_| ()),
+        );
     });
 }
+
+// #[bench]
+// fn bench_big_pipeline(b: &mut Bencher) {
+//     let mut core = Core::new().unwrap();
+//     let addr = "127.0.0.1:6379".parse().unwrap();
+
+//     let connection = client::paired_connect(&addr, &core.handle());
+//     let connection = core.run(connection).unwrap();
+
+//     let data_size = 100;
+
+//     b.iter(|| {
+//         for x in 0..data_size {
+//             let test_key = format!("test_{}", x);
+//             faf!(connection.send(resp_array!["SET", test_key, x.to_string()]));
+//         }
+//         let mut gets = Vec::with_capacity(data_size);
+//         for x in 0..data_size {
+//             let test_key = format!("test_{}", x);
+//             gets.push(connection.send(resp_array!["GET", test_key]));
+//         }
+//         let last_get = gets.remove(data_size - 1);
+//         let _: String = core.run(last_get).unwrap();
+//     });
+// }
 
 #[bench]
 fn bench_complex_pipeline(b: &mut Bencher) {
-    let mut core = Core::new().unwrap();
+    env_logger::init();
+
+    info!("TESTING");
+
+    let cpu_pool = CpuPool::new_num_cpus();
     let addr = "127.0.0.1:6379".parse().unwrap();
 
-    let connection = client::paired_connect(&addr, &core.handle());
-    let connection = Arc::new(core.run(connection).unwrap());
+    let connection = open_paired_connection(&addr, cpu_pool.clone());
+    let connection = Arc::new(connection);
 
     let data_size = 100;
 
     b.iter(|| {
-        let sets = (0..data_size).map(|x| {
-            let connection_inner = connection.clone();
-            connection
-                .send(resp_array!["INCR", "id_gen"])
-                .and_then(move |id: String| {
-                              let id = format!("id_{}", id);
-                              connection_inner.send(resp_array!["SET", &id, &x.to_string()])
-                          })
-        });
+        let connection_outer = connection.clone();
+        let sets: Vec<_> = (0..data_size)
+            .map(move |x| {
+                let connection_inner = connection_outer.clone();
+                connection_outer
+                    .send(resp_array!["INCR", "id_gen"])
+                    .and_then(move |id: String| {
+                        let id = format!("id_{}", id);
+                        connection_inner.send(resp_array!["SET", &id, &x.to_string()])
+                    })
+            })
+            .collect();
         let all_sets = futures::future::join_all(sets);
-        let _: Vec<String> = core.run(all_sets).unwrap();
+
+        cpu_pool
+            .execute(all_sets.map(|_: Vec<String>| ()).map_err(|_| ()))
+            .expect("ERROR RUNNING");
     });
+
+    println!("{:?}", cpu_pool);
 }

--- a/benches/benchmarks.rs
+++ b/benches/benchmarks.rs
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017 Ben Ashford
+ * Copyright 2017-2018 Ben Ashford
  *
  * Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
  * http://www.apache.org/licenses/LICENSE-2.0> or the MIT license

--- a/examples/monitor.rs
+++ b/examples/monitor.rs
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017 Ben Ashford
+ * Copyright 2017-2018 Ben Ashford
  *
  * Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
  * http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
@@ -9,7 +9,6 @@
  */
 
 extern crate futures;
-extern crate tokio_core;
 #[macro_use]
 extern crate redis_async;
 
@@ -17,33 +16,30 @@ use std::env;
 
 use futures::{future, Future, Sink, Stream};
 
-use tokio_core::reactor::Core;
-
 use redis_async::client;
 
 fn main() {
-    let mut core = Core::new().unwrap();
+    // TODO - uncomment
+    // let addr = env::args()
+    //     .nth(1)
+    //     .unwrap_or("127.0.0.1:6379".to_string())
+    //     .parse()
+    //     .unwrap();
 
-    let addr = env::args()
-        .nth(1)
-        .unwrap_or("127.0.0.1:6379".to_string())
-        .parse()
-        .unwrap();
+    // let monitor = client::connect(&addr)
+    //     .map_err(|e| e.into())
+    //     .and_then(|connection| {
+    //         let client::ClientConnection { sender, receiver } = connection;
+    //         sender
+    //             .send(resp_array!["MONITOR"])
+    //             .map_err(|e| e.into())
+    //             .and_then(move |_| {
+    //                 receiver.for_each(|incoming| {
+    //                     println!("{:?}", incoming);
+    //                     future::ok(())
+    //                 })
+    //             })
+    //     });
 
-    let monitor = client::connect(&addr, &core.handle())
-        .map_err(|e| e.into())
-        .and_then(|connection| {
-            let client::ClientConnection { sender, receiver } = connection;
-            sender
-                .send(resp_array!["MONITOR"])
-                .map_err(|e| e.into())
-                .and_then(move |_| {
-                              receiver.for_each(|incoming| {
-                                                    println!("{:?}", incoming);
-                                                    future::ok(())
-                                                })
-                          })
-        });
-
-    core.run(monitor).unwrap();
+    // core.run(monitor).unwrap();
 }

--- a/examples/pubsub.rs
+++ b/examples/pubsub.rs
@@ -17,27 +17,27 @@ use std::env;
 use futures::{Future, Stream};
 use futures::future;
 
+use tokio::executor::current_thread;
+
 use redis_async::client;
 use redis_async::resp::FromResp;
 
 fn main() {
-    // TODO - uncomment
-    // let topic = env::args().nth(1).unwrap_or("test-topic".to_string());
-    // let addr = env::args()
-    //     .nth(2)
-    //     .unwrap_or("127.0.0.1:6379".to_string())
-    //     .parse()
-    //     .unwrap();
+    let topic = env::args().nth(1).unwrap_or("test-topic".to_string());
+    let addr = env::args()
+        .nth(2)
+        .unwrap_or("127.0.0.1:6379".to_string())
+        .parse()
+        .unwrap();
 
-    // TODO - uncomment
-    // let msgs = client::pubsub_connect(&addr, &handle)
-    //     .and_then(move |connection| connection.subscribe(topic));
-    // let the_loop = msgs.map_err(|_| ()).and_then(|msgs| {
-    //     msgs.for_each(|message| {
-    //         println!("{}", String::from_resp(message).unwrap());
-    //         future::ok(())
-    //     })
-    // });
+    let msgs = client::pubsub_connect(&addr, current_thread::task_executor())
+        .and_then(move |connection| connection.subscribe(topic));
+    let the_loop = msgs.map_err(|_| ()).and_then(|msgs| {
+        msgs.for_each(|message| {
+            println!("{}", String::from_resp(message).unwrap());
+            future::ok(())
+        })
+    });
 
-    // core.run(the_loop).unwrap();
+    current_thread::run(|_| current_thread::spawn(the_loop));
 }

--- a/examples/pubsub.rs
+++ b/examples/pubsub.rs
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017 Ben Ashford
+ * Copyright 2017-2018 Ben Ashford
  *
  * Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
  * http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
@@ -9,39 +9,35 @@
  */
 
 extern crate futures;
-extern crate tokio_core;
 extern crate redis_async;
+extern crate tokio;
 
 use std::env;
 
 use futures::{Future, Stream};
 use futures::future;
 
-use tokio_core::reactor::Core;
-
 use redis_async::client;
 use redis_async::resp::FromResp;
 
 fn main() {
-    let mut core = Core::new().unwrap();
-    let handle = core.handle();
+    // TODO - uncomment
+    // let topic = env::args().nth(1).unwrap_or("test-topic".to_string());
+    // let addr = env::args()
+    //     .nth(2)
+    //     .unwrap_or("127.0.0.1:6379".to_string())
+    //     .parse()
+    //     .unwrap();
 
-    let topic = env::args().nth(1).unwrap_or("test-topic".to_string());
-    let addr = env::args()
-        .nth(2)
-        .unwrap_or("127.0.0.1:6379".to_string())
-        .parse()
-        .unwrap();
+    // TODO - uncomment
+    // let msgs = client::pubsub_connect(&addr, &handle)
+    //     .and_then(move |connection| connection.subscribe(topic));
+    // let the_loop = msgs.map_err(|_| ()).and_then(|msgs| {
+    //     msgs.for_each(|message| {
+    //         println!("{}", String::from_resp(message).unwrap());
+    //         future::ok(())
+    //     })
+    // });
 
-    let msgs = client::pubsub_connect(&addr, &handle)
-        .and_then(move |connection| connection.subscribe(topic));
-    let the_loop = msgs.map_err(|_| ())
-        .and_then(|msgs| {
-                      msgs.for_each(|message| {
-                                        println!("{}", String::from_resp(message).unwrap());
-                                        future::ok(())
-                                    })
-                  });
-
-    core.run(the_loop).unwrap();
+    // core.run(the_loop).unwrap();
 }

--- a/examples/realistic.rs
+++ b/examples/realistic.rs
@@ -11,11 +11,15 @@
 extern crate futures;
 #[macro_use]
 extern crate redis_async;
+extern crate tokio;
 
 use std::sync::Arc;
 use std::env;
 
 use futures::{future, Future};
+use futures::sync::oneshot;
+
+use tokio::executor::current_thread;
 
 use redis_async::client;
 
@@ -25,31 +29,46 @@ fn main() {
     let test_data_size = 10;
     let test_data: Vec<_> = (0..test_data_size).map(|x| (x, x.to_string())).collect();
 
-    // TODO - uncomment
-    // let addr = env::args()
-    //     .nth(1)
-    //     .unwrap_or("127.0.0.1:6379".to_string())
-    //     .parse()
-    //     .unwrap();
+    let addr = env::args()
+        .nth(1)
+        .unwrap_or("127.0.0.1:6379".to_string())
+        .parse()
+        .unwrap();
 
-    // let test_f = client::paired_connect(&addr);
+    let test_f = client::paired_connect(&addr, current_thread::task_executor());
+    let (tx, rx) = oneshot::channel();
 
-    // let send_data = test_f.and_then(|connection| {
-    //     let connection = Arc::new(connection);
-    //     let futures = test_data.into_iter().map(move |data| {
-    //         let connection_inner = connection.clone();
-    //         connection
-    //             .send(resp_array!["INCR", "realistic_test_ctr"])
-    //             .and_then(move |ctr: String| {
-    //                 let key = format!("rt_{}", ctr);
-    //                 let d_val = data.0.to_string();
-    //                 faf!(connection_inner.send(resp_array!["SET", &key, d_val]));
-    //                 connection_inner.send(resp_array!["SET", data.1, key])
-    //             })
-    //     });
-    //     future::join_all(futures)
-    // });
+    let send_data = test_f.and_then(|connection| {
+        let connection = Arc::new(connection);
+        let futures = test_data.into_iter().map(move |data| {
+            let connection_inner = connection.clone();
+            connection
+                .send(resp_array!["INCR", "realistic_test_ctr"])
+                .and_then(move |ctr: String| {
+                    let key = format!("rt_{}", ctr);
+                    let d_val = data.0.to_string();
+                    faf!(connection_inner.send(resp_array!["SET", &key, d_val]));
+                    connection_inner.send(resp_array!["SET", data.1, key])
+                })
+        });
+        future::join_all(futures)
+    });
+    let deliver = send_data.then(|result| match result {
+        Ok(result) => match tx.send(result) {
+            Ok(_) => future::ok(()),
+            Err(e) => {
+                println!("Unexpected error: {:?}", e);
+                future::err(())
+            }
+        },
+        Err(e) => {
+            println!("Unexpected error: {:?}", e);
+            future::err(())
+        }
+    });
 
-    // let result: Vec<String> = core.run(send_data).unwrap();
-    // assert_eq!(result.len(), test_data_size);
+    current_thread::run(|_| current_thread::spawn(deliver));
+
+    let result: Vec<String> = rx.wait().expect("Waiting for delivery");
+    assert_eq!(result.len(), test_data_size);
 }

--- a/examples/realistic.rs
+++ b/examples/realistic.rs
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017 Ben Ashford
+ * Copyright 2017-2018 Ben Ashford
  *
  * Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
  * http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
@@ -9,7 +9,6 @@
  */
 
 extern crate futures;
-extern crate tokio_core;
 #[macro_use]
 extern crate redis_async;
 
@@ -17,8 +16,6 @@ use std::sync::Arc;
 use std::env;
 
 use futures::{future, Future};
-
-use tokio_core::reactor::Core;
 
 use redis_async::client;
 
@@ -28,34 +25,31 @@ fn main() {
     let test_data_size = 10;
     let test_data: Vec<_> = (0..test_data_size).map(|x| (x, x.to_string())).collect();
 
-    let mut core = Core::new().unwrap();
+    // TODO - uncomment
+    // let addr = env::args()
+    //     .nth(1)
+    //     .unwrap_or("127.0.0.1:6379".to_string())
+    //     .parse()
+    //     .unwrap();
 
-    let addr = env::args()
-        .nth(1)
-        .unwrap_or("127.0.0.1:6379".to_string())
-        .parse()
-        .unwrap();
+    // let test_f = client::paired_connect(&addr);
 
-    let test_f = client::paired_connect(&addr, &core.handle());
+    // let send_data = test_f.and_then(|connection| {
+    //     let connection = Arc::new(connection);
+    //     let futures = test_data.into_iter().map(move |data| {
+    //         let connection_inner = connection.clone();
+    //         connection
+    //             .send(resp_array!["INCR", "realistic_test_ctr"])
+    //             .and_then(move |ctr: String| {
+    //                 let key = format!("rt_{}", ctr);
+    //                 let d_val = data.0.to_string();
+    //                 faf!(connection_inner.send(resp_array!["SET", &key, d_val]));
+    //                 connection_inner.send(resp_array!["SET", data.1, key])
+    //             })
+    //     });
+    //     future::join_all(futures)
+    // });
 
-    let send_data = test_f.and_then(|connection| {
-        let connection = Arc::new(connection);
-        let futures = test_data
-            .into_iter()
-            .map(move |data| {
-                let connection_inner = connection.clone();
-                connection
-                    .send(resp_array!["INCR", "realistic_test_ctr"])
-                    .and_then(move |ctr: String| {
-                                  let key = format!("rt_{}", ctr);
-                                  let d_val = data.0.to_string();
-                                  faf!(connection_inner.send(resp_array!["SET", &key, d_val]));
-                                  connection_inner.send(resp_array!["SET", data.1, key])
-                              })
-            });
-        future::join_all(futures)
-    });
-
-    let result: Vec<String> = core.run(send_data).unwrap();
-    assert_eq!(result.len(), test_data_size);
+    // let result: Vec<String> = core.run(send_data).unwrap();
+    // assert_eq!(result.len(), test_data_size);
 }

--- a/src/client/connect.rs
+++ b/src/client/connect.rs
@@ -29,9 +29,9 @@ pub fn connect(addr: &SocketAddr) -> Box<Future<Item = ClientConnection, Error =
     let con = TcpStream::connect(addr).map(move |socket| {
         let framed = socket.framed(resp::RespCodec);
         let (write_f, read_f) = framed.split();
-        let write_b = write_f.buffer(DEFAULT_BUFFER_SIZE);
+        // let write_b = write_f.buffer(DEFAULT_BUFFER_SIZE);
         ClientConnection {
-            sender: Box::new(write_b),
+            sender: Box::new(write_f),
             receiver: Box::new(read_f),
         }
     });

--- a/src/client/connect.rs
+++ b/src/client/connect.rs
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017 Ben Ashford
+ * Copyright 2017-2018 Ben Ashford
  *
  * Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
  * http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
@@ -13,8 +13,7 @@ use std::net::SocketAddr;
 
 use futures::{Future, Sink, Stream};
 
-use tokio_core::net::TcpStream;
-use tokio_core::reactor::Handle;
+use tokio::net::TcpStream;
 
 use tokio_io::AsyncRead;
 
@@ -26,10 +25,8 @@ const DEFAULT_BUFFER_SIZE: usize = 100;
 
 /// Connect to a Redis server and return paired Sink and Stream for reading and writing
 /// asynchronously.
-pub fn connect(addr: &SocketAddr,
-               handle: &Handle)
-               -> Box<Future<Item = ClientConnection, Error = io::Error>> {
-    let con = TcpStream::connect(addr, handle).map(move |socket| {
+pub fn connect(addr: &SocketAddr) -> Box<Future<Item = ClientConnection, Error = io::Error>> {
+    let con = TcpStream::connect(addr).map(move |socket| {
         let framed = socket.framed(resp::RespCodec);
         let (write_f, read_f) = framed.split();
         let write_b = write_f.buffer(DEFAULT_BUFFER_SIZE);

--- a/src/client/connect.rs
+++ b/src/client/connect.rs
@@ -43,6 +43,6 @@ pub fn connect(addr: &SocketAddr) -> Box<Future<Item = ClientConnection, Error =
 ///
 /// The two halves operate independently from one another
 pub struct ClientConnection {
-    pub sender: Box<Sink<SinkItem = resp::RespValue, SinkError = io::Error>>,
-    pub receiver: Box<Stream<Item = resp::RespValue, Error = error::Error>>,
+    pub sender: Box<Sink<SinkItem = resp::RespValue, SinkError = io::Error> + Send>,
+    pub receiver: Box<Stream<Item = resp::RespValue, Error = error::Error> + Send>,
 }

--- a/src/client/connect.rs
+++ b/src/client/connect.rs
@@ -25,7 +25,9 @@ const DEFAULT_BUFFER_SIZE: usize = 100;
 
 /// Connect to a Redis server and return paired Sink and Stream for reading and writing
 /// asynchronously.
-pub fn connect(addr: &SocketAddr) -> Box<Future<Item = ClientConnection, Error = io::Error>> {
+pub fn connect(
+    addr: &SocketAddr,
+) -> Box<Future<Item = ClientConnection, Error = io::Error> + Send> {
     let con = TcpStream::connect(addr).map(move |socket| {
         let framed = socket.framed(resp::RespCodec);
         let (write_f, read_f) = framed.split();

--- a/src/client/connect.rs
+++ b/src/client/connect.rs
@@ -20,9 +20,6 @@ use tokio_io::AsyncRead;
 use error;
 use resp;
 
-/// TODO: comeback and optimise this number
-const DEFAULT_BUFFER_SIZE: usize = 100;
-
 /// Connect to a Redis server and return paired Sink and Stream for reading and writing
 /// asynchronously.
 pub fn connect(
@@ -31,7 +28,6 @@ pub fn connect(
     let con = TcpStream::connect(addr).map(move |socket| {
         let framed = socket.framed(resp::RespCodec);
         let (write_f, read_f) = framed.split();
-        // let write_b = write_f.buffer(DEFAULT_BUFFER_SIZE);
         ClientConnection {
             sender: Box::new(write_f),
             receiver: Box::new(read_f),

--- a/src/client/mod.rs
+++ b/src/client/mod.rs
@@ -27,9 +27,7 @@ pub mod pubsub;
 
 pub use self::connect::{connect, ClientConnection};
 pub use self::paired::{paired_connect, PairedConnection};
-
-// TODO - uncomment
-// pub use self::pubsub::{pubsub_connect, PubsubConnection};
+pub use self::pubsub::{pubsub_connect, PubsubConnection};
 
 #[cfg(test)]
 mod test {
@@ -42,6 +40,7 @@ mod test {
 
     use tokio::executor::current_thread;
 
+    use error;
     use resp;
 
     fn extract_result<F, R, E>(f: F) -> R
@@ -168,11 +167,12 @@ mod test {
         assert_eq!(result, "999");
     }
 
+    // TODO - uncomment
     // #[test]
     // fn pubsub_test() {
     //     let addr = "127.0.0.1:6379".parse().unwrap();
-    //     let paired_c = super::paired_connect(&addr);
-    //     let pubsub_c = super::pubsub_connect(&addr);
+    //     let paired_c = super::paired_connect(&addr, current_thread::task_executor());
+    //     let pubsub_c = super::pubsub_connect(&addr, current_thread::task_executor());
     //     let msgs = paired_c.join(pubsub_c).and_then(|(paired, pubsub)| {
     //         let subscribe = pubsub.subscribe("test-topic");
     //         subscribe.and_then(move |msgs| {
@@ -188,7 +188,7 @@ mod test {
     //             .collect()
     //             .map_err(|_| error::internal("unreachable"))
     //     });
-    //     let result = core.run(tst).unwrap();
+    //     let result = extract_result(tst);
     //     assert_eq!(result.len(), 2);
     //     assert_eq!(result[0], "test-message".into());
     //     assert_eq!(result[1], "test-message2".into());

--- a/src/client/mod.rs
+++ b/src/client/mod.rs
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017 Ben Ashford
+ * Copyright 2017-2018 Ben Ashford
  *
  * Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
  * http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
@@ -26,150 +26,139 @@ pub mod paired;
 pub mod pubsub;
 
 pub use self::connect::{connect, ClientConnection};
-pub use self::paired::{paired_connect, PairedConnection};
-pub use self::pubsub::{pubsub_connect, PubsubConnection};
+// TODO - uncomment
+// pub use self::paired::{paired_connect, PairedConnection};
+// pub use self::pubsub::{pubsub_connect, PubsubConnection};
 
 #[cfg(test)]
 mod test {
     use std::io;
 
-    use futures::{Future, Sink, Stream, stream};
-
-    use tokio_core::reactor::Core;
+    use futures::{stream, Future, Sink, Stream};
 
     use error;
     use resp;
 
-    #[test]
-    fn can_connect() {
-        let mut core = Core::new().unwrap();
-        let addr = "127.0.0.1:6379".parse().unwrap();
+    // TODO - uncomment
+    // #[test]
+    // fn can_connect() {
+    //     let addr = "127.0.0.1:6379".parse().unwrap();
 
-        let connection = super::connect(&addr, &core.handle())
-            .map_err(|e| e.into())
-            .and_then(|connection| {
-                          let a = connection
-                              .sender
-                              .send(resp_array!["PING", "TEST"])
-                              .map_err(|e| e.into());
-                          let b = connection.receiver.take(1).collect();
-                          a.join(b)
-                      });
+    //     let connection = super::connect(&addr)
+    //         .map_err(|e| e.into())
+    //         .and_then(|connection| {
+    //             let a = connection
+    //                 .sender
+    //                 .send(resp_array!["PING", "TEST"])
+    //                 .map_err(|e| e.into());
+    //             let b = connection.receiver.take(1).collect();
+    //             a.join(b)
+    //         });
 
-        let (_, values) = core.run(connection).unwrap();
-        assert_eq!(values.len(), 1);
-        assert_eq!(values[0], "TEST".into());
-    }
+    //     let (_, values) = core.run(connection).unwrap();
+    //     assert_eq!(values.len(), 1);
+    //     assert_eq!(values[0], "TEST".into());
+    // }
 
-    #[test]
-    fn complex_test() {
-        let mut core = Core::new().unwrap();
-        let addr = "127.0.0.1:6379".parse().unwrap();
-        let connection = super::connect(&addr, &core.handle())
-            .map_err(|e| e.into())
-            .and_then(|connection| {
-                let mut ops = Vec::<resp::RespValue>::new();
-                ops.push(resp_array!["FLUSH"]);
-                ops.extend((0..1000).map(|i| {
-                                             resp_array!["SADD",
-                                                         "test_set",
-                                                         format!("VALUE: {}", i)]
-                                         }));
-                ops.push(resp_array!["SMEMBERS", "test_set"]);
-                let send = connection
-                    .sender
-                    .send_all(stream::iter_ok::<_, io::Error>(ops))
-                    .map_err(|e| e.into());
-                let receive = connection.receiver.skip(1001).take(1).collect();
-                send.join(receive)
-            });
-        let (_, values) = core.run(connection).unwrap();
-        assert_eq!(values.len(), 1);
-        let values = match &values[0] {
-            &resp::RespValue::Array(ref values) => values.clone(),
-            _ => panic!("Not an array"),
-        };
-        assert_eq!(values.len(), 1000);
-    }
+    // #[test]
+    // fn complex_test() {
+    //     let addr = "127.0.0.1:6379".parse().unwrap();
+    //     let connection = super::connect(&addr)
+    //         .map_err(|e| e.into())
+    //         .and_then(|connection| {
+    //             let mut ops = Vec::<resp::RespValue>::new();
+    //             ops.push(resp_array!["FLUSH"]);
+    //             ops.extend(
+    //                 (0..1000).map(|i| resp_array!["SADD", "test_set", format!("VALUE: {}", i)]),
+    //             );
+    //             ops.push(resp_array!["SMEMBERS", "test_set"]);
+    //             let send = connection
+    //                 .sender
+    //                 .send_all(stream::iter_ok::<_, io::Error>(ops))
+    //                 .map_err(|e| e.into());
+    //             let receive = connection.receiver.skip(1001).take(1).collect();
+    //             send.join(receive)
+    //         });
+    //     let (_, values) = core.run(connection).unwrap();
+    //     assert_eq!(values.len(), 1);
+    //     let values = match &values[0] {
+    //         &resp::RespValue::Array(ref values) => values.clone(),
+    //         _ => panic!("Not an array"),
+    //     };
+    //     assert_eq!(values.len(), 1000);
+    // }
 
-    #[test]
-    fn can_paired_connect() {
-        let mut core = Core::new().unwrap();
-        let addr = "127.0.0.1:6379".parse().unwrap();
+    // #[test]
+    // fn can_paired_connect() {
+    //     let addr = "127.0.0.1:6379".parse().unwrap();
 
-        let connect_f = super::paired_connect(&addr, &core.handle()).and_then(|connection| {
-            let res_f = connection.send(resp_array!["PING", "TEST"]);
-            faf!(connection.send(resp_array!["SET", "X", "123"]));
-            let wait_f = connection.send(resp_array!["GET", "X"]);
-            res_f.join(wait_f)
-        });
-        let (result_1, result_2): (String, String) = core.run(connect_f).unwrap();
-        assert_eq!(result_1, "TEST");
-        assert_eq!(result_2, "123");
-    }
+    //     let connect_f = super::paired_connect(&addr).and_then(|connection| {
+    //         let res_f = connection.send(resp_array!["PING", "TEST"]);
+    //         faf!(connection.send(resp_array!["SET", "X", "123"]));
+    //         let wait_f = connection.send(resp_array!["GET", "X"]);
+    //         res_f.join(wait_f)
+    //     });
+    //     let (result_1, result_2): (String, String) = core.run(connect_f).unwrap();
+    //     assert_eq!(result_1, "TEST");
+    //     assert_eq!(result_2, "123");
+    // }
 
-    #[test]
-    fn complex_paired_connect() {
-        let mut core = Core::new().unwrap();
-        let addr = "127.0.0.1:6379".parse().unwrap();
+    // #[test]
+    // fn complex_paired_connect() {
+    //     let addr = "127.0.0.1:6379".parse().unwrap();
 
-        let connect_f = super::paired_connect(&addr, &core.handle()).and_then(|connection| {
-            connection
-                .send(resp_array!["INCR", "CTR"])
-                .and_then(move |value: String| {
-                              connection.send(resp_array!["SET", "LASTCTR", value])
-                          })
-        });
-        let result: String = core.run(connect_f).unwrap();
-        assert_eq!(result, "OK");
-    }
+    //     let connect_f = super::paired_connect(&addr).and_then(|connection| {
+    //         connection
+    //             .send(resp_array!["INCR", "CTR"])
+    //             .and_then(move |value: String| {
+    //                 connection.send(resp_array!["SET", "LASTCTR", value])
+    //             })
+    //     });
+    //     let result: String = core.run(connect_f).unwrap();
+    //     assert_eq!(result, "OK");
+    // }
 
-    #[test]
-    fn sending_a_lot_of_data_test() {
-        let mut core = Core::new().unwrap();
-        let addr = "127.0.0.1:6379".parse().unwrap();
+    // #[test]
+    // fn sending_a_lot_of_data_test() {
+    //     let addr = "127.0.0.1:6379".parse().unwrap();
 
-        let test_f = super::paired_connect(&addr, &core.handle());
-        let send_data = test_f.and_then(|connection| {
-            let mut futures = Vec::with_capacity(1000);
-            for i in 0..1000 {
-                let key = format!("X_{}", i);
-                faf!(connection.send(resp_array!["SET", &key, i.to_string()]));
-                futures.push(connection.send(resp_array!["GET", key]));
-            }
-            futures.remove(999)
-        });
-        let result: String = core.run(send_data).unwrap();
-        assert_eq!(result, "999");
-    }
+    //     let test_f = super::paired_connect(&addr);
+    //     let send_data = test_f.and_then(|connection| {
+    //         let mut futures = Vec::with_capacity(1000);
+    //         for i in 0..1000 {
+    //             let key = format!("X_{}", i);
+    //             faf!(connection.send(resp_array!["SET", &key, i.to_string()]));
+    //             futures.push(connection.send(resp_array!["GET", key]));
+    //         }
+    //         futures.remove(999)
+    //     });
+    //     let result: String = core.run(send_data).unwrap();
+    //     assert_eq!(result, "999");
+    // }
 
-    #[test]
-    fn pubsub_test() {
-        let mut core = Core::new().unwrap();
-        let handle = core.handle();
-        let addr = "127.0.0.1:6379".parse().unwrap();
-        let paired_c = super::paired_connect(&addr, &handle);
-        let pubsub_c = super::pubsub_connect(&addr, &handle);
-        let msgs = paired_c
-            .join(pubsub_c)
-            .and_then(|(paired, pubsub)| {
-                let subscribe = pubsub.subscribe("test-topic");
-                subscribe.and_then(move |msgs| {
-                    faf!(paired.send(resp_array!["PUBLISH", "test-topic", "test-message"]));
-                    faf!(paired.send(resp_array!["PUBLISH", "test-not-topic", "test-message-1.5"]));
-                    paired
-                        .send(resp_array!["PUBLISH", "test-topic", "test-message2"])
-                        .map(|_: resp::RespValue| msgs)
-                })
-            });
-        let tst = msgs.and_then(|msgs| {
-                                    msgs.take(2)
-                                        .collect()
-                                        .map_err(|_| error::internal("unreachable"))
-                                });
-        let result = core.run(tst).unwrap();
-        assert_eq!(result.len(), 2);
-        assert_eq!(result[0], "test-message".into());
-        assert_eq!(result[1], "test-message2".into());
-    }
+    // #[test]
+    // fn pubsub_test() {
+    //     let addr = "127.0.0.1:6379".parse().unwrap();
+    //     let paired_c = super::paired_connect(&addr);
+    //     let pubsub_c = super::pubsub_connect(&addr);
+    //     let msgs = paired_c.join(pubsub_c).and_then(|(paired, pubsub)| {
+    //         let subscribe = pubsub.subscribe("test-topic");
+    //         subscribe.and_then(move |msgs| {
+    //             faf!(paired.send(resp_array!["PUBLISH", "test-topic", "test-message"]));
+    //             faf!(paired.send(resp_array!["PUBLISH", "test-not-topic", "test-message-1.5"]));
+    //             paired
+    //                 .send(resp_array!["PUBLISH", "test-topic", "test-message2"])
+    //                 .map(|_: resp::RespValue| msgs)
+    //         })
+    //     });
+    //     let tst = msgs.and_then(|msgs| {
+    //         msgs.take(2)
+    //             .collect()
+    //             .map_err(|_| error::internal("unreachable"))
+    //     });
+    //     let result = core.run(tst).unwrap();
+    //     assert_eq!(result.len(), 2);
+    //     assert_eq!(result[0], "test-message".into());
+    //     assert_eq!(result[1], "test-message2".into());
+    // }
 }

--- a/src/client/mod.rs
+++ b/src/client/mod.rs
@@ -134,38 +134,39 @@ mod test {
         assert_eq!(result_2, "123");
     }
 
-    // #[test]
-    // fn complex_paired_connect() {
-    //     let addr = "127.0.0.1:6379".parse().unwrap();
+    #[test]
+    fn complex_paired_connect() {
+        let addr = "127.0.0.1:6379".parse().unwrap();
 
-    //     let connect_f = super::paired_connect(&addr).and_then(|connection| {
-    //         connection
-    //             .send(resp_array!["INCR", "CTR"])
-    //             .and_then(move |value: String| {
-    //                 connection.send(resp_array!["SET", "LASTCTR", value])
-    //             })
-    //     });
-    //     let result: String = core.run(connect_f).unwrap();
-    //     assert_eq!(result, "OK");
-    // }
+        let connect_f =
+            super::paired_connect(&addr, current_thread::task_executor()).and_then(|connection| {
+                connection
+                    .send(resp_array!["INCR", "CTR"])
+                    .and_then(move |value: String| {
+                        connection.send(resp_array!["SET", "LASTCTR", value])
+                    })
+            });
+        let result: String = extract_result(connect_f);
+        assert_eq!(result, "OK");
+    }
 
-    // #[test]
-    // fn sending_a_lot_of_data_test() {
-    //     let addr = "127.0.0.1:6379".parse().unwrap();
+    #[test]
+    fn sending_a_lot_of_data_test() {
+        let addr = "127.0.0.1:6379".parse().unwrap();
 
-    //     let test_f = super::paired_connect(&addr);
-    //     let send_data = test_f.and_then(|connection| {
-    //         let mut futures = Vec::with_capacity(1000);
-    //         for i in 0..1000 {
-    //             let key = format!("X_{}", i);
-    //             faf!(connection.send(resp_array!["SET", &key, i.to_string()]));
-    //             futures.push(connection.send(resp_array!["GET", key]));
-    //         }
-    //         futures.remove(999)
-    //     });
-    //     let result: String = core.run(send_data).unwrap();
-    //     assert_eq!(result, "999");
-    // }
+        let test_f = super::paired_connect(&addr, current_thread::task_executor());
+        let send_data = test_f.and_then(|connection| {
+            let mut futures = Vec::with_capacity(1000);
+            for i in 0..1000 {
+                let key = format!("X_{}", i);
+                faf!(connection.send(resp_array!["SET", &key, i.to_string()]));
+                futures.push(connection.send(resp_array!["GET", key]));
+            }
+            futures.remove(999)
+        });
+        let result: String = extract_result(send_data);
+        assert_eq!(result, "999");
+    }
 
     // #[test]
     // fn pubsub_test() {

--- a/src/client/mod.rs
+++ b/src/client/mod.rs
@@ -112,27 +112,27 @@ mod test {
         assert_eq!(values.len(), 1000);
     }
 
-    // #[test]
-    // fn can_paired_connect() {
-    //     let addr = "127.0.0.1:6379".parse().unwrap();
+    #[test]
+    fn can_paired_connect() {
+        let addr = "127.0.0.1:6379".parse().unwrap();
 
-    //     let connect_f =
-    //         super::paired_connect(&addr, current_thread::task_executor()).and_then(|connection| {
-    //             let res_f = connection.send(resp_array!["PING", "TEST"]).map(|v| {
-    //                 println!("FIRST: {:?}", v);
-    //                 v
-    //             });
-    //             faf!(connection.send(resp_array!["SET", "X", "123"]));
-    //             let wait_f = connection.send(resp_array!["GET", "X"]).map(|v| {
-    //                 println!("THIRD: {:?}", v);
-    //                 v
-    //             });
-    //             res_f.join(wait_f)
-    //         });
-    //     let (result_1, result_2): (String, String) = extract_result(connect_f);
-    //     assert_eq!(result_1, "TEST");
-    //     assert_eq!(result_2, "123");
-    // }
+        let connect_f =
+            super::paired_connect(&addr, current_thread::task_executor()).and_then(|connection| {
+                let res_f = connection.send(resp_array!["PING", "TEST"]).map(|v| {
+                    println!("FIRST: {:?}", v);
+                    v
+                });
+                faf!(connection.send(resp_array!["SET", "X", "123"]));
+                let wait_f = connection.send(resp_array!["GET", "X"]).map(|v| {
+                    println!("THIRD: {:?}", v);
+                    v
+                });
+                res_f.join(wait_f)
+            });
+        let (result_1, result_2): (String, String) = extract_result(connect_f);
+        assert_eq!(result_1, "TEST");
+        assert_eq!(result_2, "123");
+    }
 
     // #[test]
     // fn complex_paired_connect() {

--- a/src/client/mod.rs
+++ b/src/client/mod.rs
@@ -73,33 +73,33 @@ mod test {
         assert_eq!(values[0], "TEST".into());
     }
 
-    // #[test]
-    // fn complex_test() {
-    //     let addr = "127.0.0.1:6379".parse().unwrap();
-    //     let connection = super::connect(&addr)
-    //         .map_err(|e| e.into())
-    //         .and_then(|connection| {
-    //             let mut ops = Vec::<resp::RespValue>::new();
-    //             ops.push(resp_array!["FLUSH"]);
-    //             ops.extend(
-    //                 (0..1000).map(|i| resp_array!["SADD", "test_set", format!("VALUE: {}", i)]),
-    //             );
-    //             ops.push(resp_array!["SMEMBERS", "test_set"]);
-    //             let send = connection
-    //                 .sender
-    //                 .send_all(stream::iter_ok::<_, io::Error>(ops))
-    //                 .map_err(|e| e.into());
-    //             let receive = connection.receiver.skip(1001).take(1).collect();
-    //             send.join(receive)
-    //         });
-    //     let (_, values) = core.run(connection).unwrap();
-    //     assert_eq!(values.len(), 1);
-    //     let values = match &values[0] {
-    //         &resp::RespValue::Array(ref values) => values.clone(),
-    //         _ => panic!("Not an array"),
-    //     };
-    //     assert_eq!(values.len(), 1000);
-    // }
+    #[test]
+    fn complex_test() {
+        let addr = "127.0.0.1:6379".parse().unwrap();
+        let connection = super::connect(&addr)
+            .map_err(|e| e.into())
+            .and_then(|connection| {
+                let mut ops = Vec::<resp::RespValue>::new();
+                ops.push(resp_array!["FLUSH"]);
+                ops.extend(
+                    (0..1000).map(|i| resp_array!["SADD", "test_set", format!("VALUE: {}", i)]),
+                );
+                ops.push(resp_array!["SMEMBERS", "test_set"]);
+                let send = connection
+                    .sender
+                    .send_all(stream::iter_ok::<_, io::Error>(ops))
+                    .map_err(|e| e.into());
+                let receive = connection.receiver.skip(1001).take(1).collect();
+                send.join(receive)
+            });
+        let (_, values) = extract_result(connection);
+        assert_eq!(values.len(), 1);
+        let values = match &values[0] {
+            &resp::RespValue::Array(ref values) => values.clone(),
+            _ => panic!("Not an array"),
+        };
+        assert_eq!(values.len(), 1000);
+    }
 
     // #[test]
     // fn can_paired_connect() {

--- a/src/client/mod.rs
+++ b/src/client/mod.rs
@@ -167,30 +167,29 @@ mod test {
         assert_eq!(result, "999");
     }
 
-    // TODO - uncomment
-    // #[test]
-    // fn pubsub_test() {
-    //     let addr = "127.0.0.1:6379".parse().unwrap();
-    //     let paired_c = super::paired_connect(&addr, current_thread::task_executor());
-    //     let pubsub_c = super::pubsub_connect(&addr, current_thread::task_executor());
-    //     let msgs = paired_c.join(pubsub_c).and_then(|(paired, pubsub)| {
-    //         let subscribe = pubsub.subscribe("test-topic");
-    //         subscribe.and_then(move |msgs| {
-    //             faf!(paired.send(resp_array!["PUBLISH", "test-topic", "test-message"]));
-    //             faf!(paired.send(resp_array!["PUBLISH", "test-not-topic", "test-message-1.5"]));
-    //             paired
-    //                 .send(resp_array!["PUBLISH", "test-topic", "test-message2"])
-    //                 .map(|_: resp::RespValue| msgs)
-    //         })
-    //     });
-    //     let tst = msgs.and_then(|msgs| {
-    //         msgs.take(2)
-    //             .collect()
-    //             .map_err(|_| error::internal("unreachable"))
-    //     });
-    //     let result = extract_result(tst);
-    //     assert_eq!(result.len(), 2);
-    //     assert_eq!(result[0], "test-message".into());
-    //     assert_eq!(result[1], "test-message2".into());
-    // }
+    #[test]
+    fn pubsub_test() {
+        let addr = "127.0.0.1:6379".parse().unwrap();
+        let paired_c = super::paired_connect(&addr, current_thread::task_executor());
+        let pubsub_c = super::pubsub_connect(&addr, current_thread::task_executor());
+        let msgs = paired_c.join(pubsub_c).and_then(|(paired, pubsub)| {
+            let subscribe = pubsub.subscribe("test-topic");
+            subscribe.and_then(move |msgs| {
+                faf!(paired.send(resp_array!["PUBLISH", "test-topic", "test-message"]));
+                faf!(paired.send(resp_array!["PUBLISH", "test-not-topic", "test-message-1.5"]));
+                paired
+                    .send(resp_array!["PUBLISH", "test-topic", "test-message2"])
+                    .map(|_: resp::RespValue| msgs)
+            })
+        });
+        let tst = msgs.and_then(|msgs| {
+            msgs.take(2)
+                .collect()
+                .map_err(|_| error::internal("unreachable"))
+        });
+        let result = extract_result(tst);
+        assert_eq!(result.len(), 2);
+        assert_eq!(result[0], "test-message".into());
+        assert_eq!(result[1], "test-message2".into());
+    }
 }

--- a/src/client/pubsub.rs
+++ b/src/client/pubsub.rs
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017 Ben Ashford
+ * Copyright 2017-2018 Ben Ashford
  *
  * Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
  * http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
@@ -16,8 +16,6 @@ use futures::{Future, Sink, Stream};
 use futures::future;
 use futures::sync::{mpsc, oneshot};
 
-use tokio_core::reactor::Handle;
-
 use error;
 use resp;
 use resp::FromResp;
@@ -26,87 +24,91 @@ use super::connect::{connect, ClientConnection};
 /// Used for Redis's PUBSUB functionality.
 ///
 /// Returns a future that resolves to a `PubsubConnection`.
-pub fn pubsub_connect(addr: &SocketAddr,
-                      handle: &Handle)
-                      -> Box<Future<Item = PubsubConnection, Error = error::Error>> {
-    let handle = handle.clone();
-    let pubsub_con = connect(addr, &handle)
-        .map(move |connection| {
-            let ClientConnection { sender, receiver } = connection;
-            let (out_tx, out_rx) = mpsc::unbounded();
-            let sender = out_rx.fold(sender, |sender, msg| sender.send(msg).map_err(|_| ()));
-            let subs = Arc::new(Mutex::new(PubsubSubscriptions {
-                                               pending: HashMap::new(),
-                                               confirmed: HashMap::new(),
-                                           }));
-            let subs_reader = subs.clone();
-            let receiver = receiver.for_each(move |msg| {
-                // TODO: check message type - and handle accordingly.
-                let (message_type, topic, msg) = if let resp::RespValue::Array(mut messages) =
-                    msg {
-                    assert_eq!(messages.len(), 3);
-                    let msg = messages.pop().expect("No message");
-                    let topic = messages.pop().expect("No topic");
-                    let message_type = messages.pop().expect("No type");
-                    (message_type, String::from_resp(topic).expect("Topic should be a string"), msg)
-                } else {
-                    panic!("incorrect type");
-                };
-                let mut subs = subs_reader.lock().expect("Lock is tainted");
-                if let resp::RespValue::BulkString(ref bytes) = message_type {
-                    if bytes == b"subscribe" {
-                        if let Some(pending) = subs.pending.remove(&topic) {
-                            let mut txes = Vec::with_capacity(pending.len());
-                            let mut futures = Vec::with_capacity(pending.len());
-                            for (tx, notification_tx) in pending {
-                                txes.push(tx);
-                                futures.push(notification_tx.send(()));
-                            }
-                            subs.confirmed.entry(topic).or_insert(vec![]).extend(txes);
-                            let futures = future::join_all(futures)
-                                .map(|_| ())
-                                .map_err(|_| error::internal("unreachable"));
-                            Box::new(futures) as Box<Future<Item = (), Error = error::Error>>
-                        } else {
-                            let ok = future::ok(()).map_err(|_: ()| error::internal("unreachable"));
-                            Box::new(ok) as Box<Future<Item = (), Error = error::Error>>
-                        }
-                    } else if bytes == b"message" {
-                        match subs.confirmed.get(&topic) {
-                            Some(txes) => {
-                                let futures: Vec<_> = txes.iter()
-                                    .map(|tx| {
-                                             let tx = tx.clone();
-                                             tx.send(msg.clone())
-                                         })
-                                    .collect();
-                                let futures =
-                                    future::join_all(futures).map(|_| ()).map_err(|e| e.into());
-                                Box::new(futures) as Box<Future<Item = (), Error = error::Error>>
-                            }
-                            None => {
-                                let ok = future::ok(())
-                                    .map_err(|_: ()| error::internal("unreachable"));
-                                Box::new(ok) as Box<Future<Item = (), Error = error::Error>>
-                            }
-                        }
-                    } else {
-                        panic!("Unexpected bytes: {:?}", bytes);
-                    }
-                } else {
-                    panic!("Message format error: {:?}", message_type);
-                }
-            });
-            handle.spawn(sender.map(|_| ()));
-            handle.spawn(receiver.map_err(|_| ()));
-            PubsubConnection {
-                out_tx: out_tx,
-                subscriptions: subs,
-            }
-        })
-        .map_err(|e| e.into());
-    Box::new(pubsub_con)
-}
+//
+// TODO - uncomment
+// pub fn pubsub_connect(
+//     addr: &SocketAddr,
+// ) -> Box<Future<Item = PubsubConnection, Error = error::Error>> {
+//     let pubsub_con = connect(addr)
+//         .map(move |connection| {
+//             let ClientConnection { sender, receiver } = connection;
+//             let (out_tx, out_rx) = mpsc::unbounded();
+//             let sender = out_rx.fold(sender, |sender, msg| sender.send(msg).map_err(|_| ()));
+//             let subs = Arc::new(Mutex::new(PubsubSubscriptions {
+//                 pending: HashMap::new(),
+//                 confirmed: HashMap::new(),
+//             }));
+//             let subs_reader = subs.clone();
+//             let receiver = receiver.for_each(move |msg| {
+//                 // TODO: check message type - and handle accordingly.
+//                 let (message_type, topic, msg) = if let resp::RespValue::Array(mut messages) = msg {
+//                     assert_eq!(messages.len(), 3);
+//                     let msg = messages.pop().expect("No message");
+//                     let topic = messages.pop().expect("No topic");
+//                     let message_type = messages.pop().expect("No type");
+//                     (
+//                         message_type,
+//                         String::from_resp(topic).expect("Topic should be a string"),
+//                         msg,
+//                     )
+//                 } else {
+//                     panic!("incorrect type");
+//                 };
+//                 let mut subs = subs_reader.lock().expect("Lock is tainted");
+//                 if let resp::RespValue::BulkString(ref bytes) = message_type {
+//                     if bytes == b"subscribe" {
+//                         if let Some(pending) = subs.pending.remove(&topic) {
+//                             let mut txes = Vec::with_capacity(pending.len());
+//                             let mut futures = Vec::with_capacity(pending.len());
+//                             for (tx, notification_tx) in pending {
+//                                 txes.push(tx);
+//                                 futures.push(notification_tx.send(()));
+//                             }
+//                             subs.confirmed.entry(topic).or_insert(vec![]).extend(txes);
+//                             let futures = future::join_all(futures)
+//                                 .map(|_| ())
+//                                 .map_err(|_| error::internal("unreachable"));
+//                             Box::new(futures) as Box<Future<Item = (), Error = error::Error>>
+//                         } else {
+//                             let ok = future::ok(()).map_err(|_: ()| error::internal("unreachable"));
+//                             Box::new(ok) as Box<Future<Item = (), Error = error::Error>>
+//                         }
+//                     } else if bytes == b"message" {
+//                         match subs.confirmed.get(&topic) {
+//                             Some(txes) => {
+//                                 let futures: Vec<_> = txes.iter()
+//                                     .map(|tx| {
+//                                         let tx = tx.clone();
+//                                         tx.send(msg.clone())
+//                                     })
+//                                     .collect();
+//                                 let futures =
+//                                     future::join_all(futures).map(|_| ()).map_err(|e| e.into());
+//                                 Box::new(futures) as Box<Future<Item = (), Error = error::Error>>
+//                             }
+//                             None => {
+//                                 let ok =
+//                                     future::ok(()).map_err(|_: ()| error::internal("unreachable"));
+//                                 Box::new(ok) as Box<Future<Item = (), Error = error::Error>>
+//                             }
+//                         }
+//                     } else {
+//                         panic!("Unexpected bytes: {:?}", bytes);
+//                     }
+//                 } else {
+//                     panic!("Message format error: {:?}", message_type);
+//                 }
+//             });
+//             handle.spawn(sender.map(|_| ()));
+//             handle.spawn(receiver.map_err(|_| ()));
+//             PubsubConnection {
+//                 out_tx: out_tx,
+//                 subscriptions: subs,
+//             }
+//         })
+//         .map_err(|e| e.into());
+//     Box::new(pubsub_con)
+// }
 
 struct PubsubSubscriptions {
     pending: HashMap<String, Vec<(mpsc::Sender<resp::RespValue>, oneshot::Sender<()>)>>,
@@ -124,11 +126,11 @@ impl PubsubConnection {
     ///
     /// Returns a future that resolves to a `Stream` that contains all the messages published on
     /// that particular topic.
-    pub fn subscribe<T: Into<String>>
-        (&self,
-         topic: T)
-         -> Box<Future<Item = Box<Stream<Item = resp::RespValue, Error = ()>>,
-                       Error = error::Error>> {
+    pub fn subscribe<T: Into<String>>(
+        &self,
+        topic: T,
+    ) -> Box<Future<Item = Box<Stream<Item = resp::RespValue, Error = ()>>, Error = error::Error>>
+    {
         let topic = topic.into();
         let mut subs = self.subscriptions.lock().expect("Lock is tainted");
 

--- a/src/error.rs
+++ b/src/error.rs
@@ -30,6 +30,9 @@ pub enum Error {
     /// A remote error
     Remote(String),
 
+    /// End of stream - not necesserially an error if you're anticipating it
+    EndOfStream,
+
     /// An unexpected error, boxed to allow type-erasure.  In this context "unexpected" means
     /// "unexpected because we check ahead of time", it used to maintain the type signature of
     /// chains of futures; but it occurring at runtime should be considered a catastrophic
@@ -70,6 +73,7 @@ impl error::Error for Error {
             Error::IO(ref err) => err.description(),
             Error::RESP(ref s, _) => s,
             Error::Remote(ref s) => s,
+            Error::EndOfStream => "End of Stream",
             Error::Unexpected(ref err) => err.description(),
         }
     }
@@ -80,6 +84,7 @@ impl error::Error for Error {
             Error::IO(ref err) => Some(err),
             Error::RESP(_, _) => None,
             Error::Remote(_) => None,
+            Error::EndOfStream => None,
             Error::Unexpected(ref err) => Some(err.as_ref()),
         }
     }

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017 Ben Ashford
+ * Copyright 2017-2018 Ben Ashford
  *
  * Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
  * http://www.apache.org/licenses/LICENSE-2.0> or the MIT license

--- a/src/error.rs
+++ b/src/error.rs
@@ -37,7 +37,7 @@ pub enum Error {
     /// "unexpected because we check ahead of time", it used to maintain the type signature of
     /// chains of futures; but it occurring at runtime should be considered a catastrophic
     /// failure.
-    Unexpected(Box<error::Error>),
+    Unexpected(Box<error::Error + Send>),
 }
 
 pub fn internal<T: Into<String>>(msg: T) -> Error {
@@ -60,7 +60,7 @@ impl From<oneshot::Canceled> for Error {
     }
 }
 
-impl<T: 'static> From<mpsc::SendError<T>> for Error {
+impl<T: 'static + Send> From<mpsc::SendError<T>> for Error {
     fn from(err: mpsc::SendError<T>) -> Error {
         Error::Unexpected(Box::new(err))
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017 Ben Ashford
+ * Copyright 2017-2018 Ben Ashford
  *
  * Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
  * http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
@@ -55,7 +55,7 @@
 
 extern crate bytes;
 extern crate futures;
-extern crate tokio_core;
+extern crate tokio;
 extern crate tokio_io;
 
 #[macro_use]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -55,6 +55,8 @@
 
 extern crate bytes;
 extern crate futures;
+#[macro_use]
+extern crate log;
 extern crate tokio;
 extern crate tokio_io;
 


### PR DESCRIPTION
Uses the new `tokio` library rather than `tokio-core` as previous.

This introduces a few subtle breaking-changes, e.g. accepting an `Executor` for background processing rather than the a `Handle` on the Tokio `Reactor`.  But code using one should be able to be upgraded without significant problems.