### PR TITLE
Allow pubsub to be used with CpuPools

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "redis-async"
-version = "0.1.0"
+version = "0.1.1"
 authors = ["Ben Ashford <benashford@users.noreply.github.com>"]
 license = "MIT/Apache-2.0"
 readme = "README.md"


### PR DESCRIPTION
And allow Errors to be more useful by avoiding the boxing that was limiting the propagation.