### PR TITLE
Reconnect

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "redis-async"
-version = "0.3.2"
+version = "0.4.0"
 authors = ["Ben Ashford <benashford@users.noreply.github.com>"]
 license = "MIT/Apache-2.0"
 readme = "README.md"
@@ -12,9 +12,10 @@ keywords = ["redis", "tokio"]
 bytes = "0.4.5"
 futures = "0.1.18"
 log = "0.4.1"
+tokio-codec = "0.1"
 tokio-executor = "0.1"
-tokio-tcp = "0.1"
 tokio-io = "0.1.6"
+tokio-tcp = "0.1"
 tokio-timer = "0.2.4"
 
 [dev-dependencies]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,6 +15,7 @@ log = "0.4.1"
 tokio-executor = "0.1"
 tokio-tcp = "0.1"
 tokio-io = "0.1.6"
+tokio-timer = "0.2.4"
 
 [dev-dependencies]
 tokio = "0.1.5"

--- a/src/client/connect.rs
+++ b/src/client/connect.rs
@@ -13,9 +13,9 @@ use std::net::SocketAddr;
 
 use futures::Future;
 
-use tokio_tcp::TcpStream;
+use tokio_codec::{Decoder, Framed};
 
-use tokio_io::{codec::Framed, AsyncRead};
+use tokio_tcp::TcpStream;
 
 use resp;
 
@@ -37,5 +37,5 @@ pub type RespConnection = Framed<TcpStream, resp::RespCodec>;
 /// But since most Redis usages involve issue commands that result in one
 /// single result, this library also implements `paired_connect`.
 pub fn connect(addr: &SocketAddr) -> impl Future<Item = RespConnection, Error = io::Error> {
-    TcpStream::connect(addr).map(move |socket| socket.framed(resp::RespCodec))
+    TcpStream::connect(addr).map(move |socket| resp::RespCodec.framed(socket))
 }

--- a/src/client/mod.rs
+++ b/src/client/mod.rs
@@ -40,6 +40,7 @@ mod test {
 
     use tokio;
 
+    use error;
     use resp;
 
     fn run_and_wait<R, E, F>(f: F) -> Result<R, E>
@@ -147,34 +148,33 @@ mod test {
         assert_eq!(result, "999");
     }
 
-    // TODO - re-enable
-    // #[test]
-    // fn pubsub_test() {
-    //     let addr = "127.0.0.1:6379".parse().unwrap();
-    //     let paired_c = super::paired_connect(&addr);
-    //     let pubsub_c = super::pubsub_connect(&addr);
-    //     let msgs = paired_c.join(pubsub_c).and_then(|(paired, pubsub)| {
-    //         let subscribe = pubsub.subscribe("test-topic");
-    //         subscribe.and_then(move |msgs| {
-    //             paired.send_and_forget(resp_array!["PUBLISH", "test-topic", "test-message"]);
-    //             paired.send_and_forget(resp_array![
-    //                 "PUBLISH",
-    //                 "test-not-topic",
-    //                 "test-message-1.5"
-    //             ]);
-    //             paired
-    //                 .send(resp_array!["PUBLISH", "test-topic", "test-message2"])
-    //                 .map(|_: resp::RespValue| msgs)
-    //         })
-    //     });
-    //     let tst = msgs.and_then(|msgs| {
-    //         msgs.take(2)
-    //             .collect()
-    //             .map_err(|_| error::internal("unreachable"))
-    //     });
-    //     let result = run_and_wait(tst).unwrap();
-    //     assert_eq!(result.len(), 2);
-    //     assert_eq!(result[0], "test-message".into());
-    //     assert_eq!(result[1], "test-message2".into());
-    // }
+    #[test]
+    fn pubsub_test() {
+        let addr = "127.0.0.1:6379".parse().unwrap();
+        let paired_c = super::paired_connect(&addr);
+        let pubsub_c = super::pubsub_connect(&addr);
+        let msgs = paired_c.join(pubsub_c).and_then(|(paired, pubsub)| {
+            let subscribe = pubsub.subscribe("test-topic");
+            subscribe.and_then(move |msgs| {
+                paired.send_and_forget(resp_array!["PUBLISH", "test-topic", "test-message"]);
+                paired.send_and_forget(resp_array![
+                    "PUBLISH",
+                    "test-not-topic",
+                    "test-message-1.5"
+                ]);
+                paired
+                    .send(resp_array!["PUBLISH", "test-topic", "test-message2"])
+                    .map(|_: resp::RespValue| msgs)
+            })
+        });
+        let tst = msgs.and_then(|msgs| {
+            msgs.take(2)
+                .collect()
+                .map_err(|_| error::internal("unreachable"))
+        });
+        let result = run_and_wait(tst).unwrap();
+        assert_eq!(result.len(), 2);
+        assert_eq!(result[0], "test-message".into());
+        assert_eq!(result[1], "test-message2".into());
+    }
 }

--- a/src/client/paired.rs
+++ b/src/client/paired.rs
@@ -256,16 +256,6 @@ impl PairedConnection {
                 Err(e) => future::err(e.into()),
             })
         }))
-
-        // if let Err(_e) = self.out_tx.unbounded_send((msg, tx)) {
-        //     // receiving end of a channel droppped
-        //     return Either::B(future::err(error::Error::EndOfStream));
-        // }
-
-        // Either::A(rx.then(|v| match v {
-        //     Ok(v) => future::result(T::from_resp(v)),
-        //     Err(e) => future::err(e.into()),
-        // }))
     }
 
     pub fn send_and_forget(&self, msg: resp::RespValue) {

--- a/src/error.rs
+++ b/src/error.rs
@@ -30,7 +30,7 @@ pub enum Error {
     /// A remote error
     Remote(String),
 
-    /// End of stream - not necesserially an error if you're anticipating it
+    /// End of stream - a connection is broken, or could not be established in the first place
     EndOfStream,
 
     /// An unexpected error.  In this context "unexpected" means

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -63,6 +63,7 @@ extern crate tokio;
 extern crate tokio_executor;
 extern crate tokio_io;
 extern crate tokio_tcp;
+extern crate tokio_timer;
 
 #[macro_use]
 pub mod resp;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -60,6 +60,7 @@ extern crate log;
 
 #[cfg(test)]
 extern crate tokio;
+extern crate tokio_codec;
 extern crate tokio_executor;
 extern crate tokio_io;
 extern crate tokio_tcp;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -71,3 +71,5 @@ pub mod resp;
 pub mod client;
 
 pub mod error;
+
+pub mod reconnect;

--- a/src/reconnect.rs
+++ b/src/reconnect.rs
@@ -1,0 +1,170 @@
+/*
+ * Copyright 2018 Ben Ashford
+ *
+ * Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+ * http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+ * <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+ * option. This file may not be copied, modified, or distributed
+ * except according to those terms.
+ */
+
+use std::error as std_error;
+use std::sync::{Arc, Mutex, RwLock};
+
+use futures::{future::Either, sync::oneshot, Future};
+
+use tokio_executor::{DefaultExecutor, Executor};
+
+#[derive(Debug)]
+pub(crate) enum ReconnectError {
+    ConnectionDropped,
+    ConnectionFailed,
+}
+
+pub(crate) struct Reconnect<A, T, RE, CE> {
+    state: Arc<RwLock<ReconnectState<T, A>>>,
+
+    work_fn: Arc<Fn(&T, A) -> Box<Future<Item = (), Error = RE> + Send> + Send + Sync>,
+    conn_fn: Arc<Fn() -> Box<Future<Item = T, Error = CE> + Send> + Send + Sync>,
+}
+
+pub(crate) fn reconnect<A, T, RE, CE, W, C>(w: W, c: C) -> Reconnect<A, T, RE, CE>
+where
+    A: Send + 'static,
+    W: Fn(&T, A) -> Box<Future<Item = (), Error = RE> + Send> + Send + Sync + 'static,
+    C: Fn() -> Box<Future<Item = T, Error = CE> + Send> + Send + Sync + 'static,
+    T: Clone + Send + Sync + 'static,
+    RE: std_error::Error + 'static,
+    CE: std_error::Error + 'static,
+{
+    let r = Reconnect {
+        state: Arc::new(RwLock::new(ReconnectState::Initialising)),
+
+        work_fn: Arc::new(w),
+        conn_fn: Arc::new(c),
+    };
+    r.reconnect();
+    r
+}
+
+struct PendingAction<A> {
+    result_c: oneshot::Sender<Box<Future<Item = (), Error = ReconnectError> + Send>>,
+    action: A,
+}
+
+enum ReconnectState<T, A> {
+    Initialising,
+    Good(T),
+    Pending(Mutex<Vec<PendingAction<A>>>),
+}
+
+use self::ReconnectState::*;
+
+impl<A, T, RE, CE> Reconnect<A, T, RE, CE>
+where
+    A: Send + 'static,
+    T: Clone + Send + Sync + 'static,
+    RE: std_error::Error + 'static,
+    CE: std_error::Error + 'static,
+{
+    fn call_work(&self, t: &T, a: A) -> impl Future<Item = (), Error = ReconnectError> {
+        let reconnect = self.clone();
+        (self.work_fn)(t, a).map_err(move |e| {
+            error!("Cannot perform action: {}", e);
+            reconnect.reconnect();
+            ReconnectError::ConnectionDropped
+        })
+    }
+
+    pub(crate) fn do_work(&self, a: A) -> impl Future<Item = (), Error = ReconnectError> {
+        let state = self.state.read().expect("Cannot obtain read lock");
+        match *state {
+            Initialising => panic!("Invalid state, this should be an impossible condition as `do_work` can only be called after `reconnect`"),
+            Good(ref t) => Either::A(self.call_work(t, a)),
+            Pending(ref pending) => {
+                let mut pending = pending.lock().expect("Cannot lock pending");
+                let (tx, rx) = oneshot::channel();
+
+                pending.push(PendingAction {
+                    result_c: tx,
+                    action: a,
+                });
+
+                let r = rx.map_err(|_| ReconnectError::ConnectionFailed).and_then(|o| {
+                    o
+                });
+                
+                Either::B(r)
+            }
+        }
+    }
+
+    pub(crate) fn reconnect(&self) {
+        let mut state = self.state.write().expect("Cannot obtain write lock");
+        if state.is_pending() {
+            warn!("Trying to reconnect when already reconnecting");
+            return;
+        }
+        *state = ReconnectState::Pending(Mutex::new(Vec::new()));
+
+        let reconnect = self.clone();
+        let connect_f = (self.conn_fn)();
+
+        let connect_f = connect_f.then(move |t| {
+            let mut state = reconnect.state.write().expect("Cannot obtain write lock");
+            match *state {
+                Initialising => panic!("Invalid state, this should be Pending"),
+                Good(_) => {
+                    return Ok(match t {
+                        Ok(_) => warn!("Attempting to reset a state to good that is already good, dropping new connection instead"),
+                        Err(e) => error!("Cannot create a new connection, but connection is good anyway due to another connection: {}", e),
+                    })
+                }
+                Pending(ref pending) => {
+                    match t {
+                        Ok(ref t) => {
+                            let mut pending = pending.lock().expect("Cannot obtain lock");
+                            for PendingAction { result_c, action } in pending.drain(..) {
+                                let _ = result_c.send(Box::new(reconnect.call_work(&t, action)));
+                            }
+                        },
+                        Err(ref e) => error!("Cannot create a new connection, pending requests will be rejected, subsequent requests will initialise a new connection: {}", e),
+                    }
+                }
+            }
+            match t {
+                Ok(t) => {
+                    *state = ReconnectState::Good(t);
+                    Ok(())
+                }
+                Err(_) => Err(()),
+            }
+        });
+
+        let mut executor = DefaultExecutor::current();
+
+        executor
+            .spawn(Box::new(connect_f.map_err(|_| panic!("Error connecting"))))
+            .expect("Cannot spawn future");
+    }
+}
+
+impl<T, A> ReconnectState<T, A> {
+    fn is_pending(&self) -> bool {
+        match self {
+            Initialising => false,
+            Good(_) => false,
+            Pending(_) => true,
+        }
+    }
+}
+
+impl<A, T, RE, CE> Clone for Reconnect<A, T, RE, CE> {
+    fn clone(&self) -> Self {
+        Reconnect {
+            state: self.state.clone(),
+            work_fn: self.work_fn.clone(),
+            conn_fn: self.conn_fn.clone(),
+        }
+    }
+}

--- a/src/reconnect.rs
+++ b/src/reconnect.rs
@@ -144,7 +144,7 @@ where
         let mut executor = DefaultExecutor::current();
 
         executor
-            .spawn(Box::new(connect_f.map_err(|_| panic!("Error connecting"))))
+            .spawn(Box::new(connect_f))
             .expect("Cannot spawn future");
     }
 }

--- a/src/resp.rs
+++ b/src/resp.rs
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017 Ben Ashford
+ * Copyright 2017-2018 Ben Ashford
  *
  * Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
  * http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
@@ -233,13 +233,13 @@ macro_rules! resp_array {
 }
 
 macro_rules! into_resp {
-    ($t:ty,$f:ident) => {
+    ($t:ty, $f:ident) => {
         impl<'a> From<$t> for RespValue {
             fn from(from: $t) -> RespValue {
                 from.$f()
             }
         }
-    }
+    };
 }
 
 /// A specific trait to convert into a `RespValue::BulkString`
@@ -250,7 +250,7 @@ pub trait ToRespString {
 macro_rules! string_into_resp {
     ($t:ty) => {
         into_resp!($t, to_resp_string);
-    }
+    };
 }
 
 impl ToRespString for String {
@@ -295,7 +295,7 @@ pub trait ToRespInteger {
 macro_rules! integer_into_resp {
     ($t:ty) => {
         into_resp!($t, to_resp_integer);
-    }
+    };
 }
 
 impl ToRespInteger for usize {


### PR DESCRIPTION
Automatically reconnect to a Redis instance if the connection is lost.

This is implemented for `PairedConnection` and `PubsubConnection`.  The first Redis call following a disruption would fail, and trigger a reconnection attempt; if the reconnection was successful, subsequent calls would succeed, otherwise they would trigger further reconnection attempts.

There is no attempt to automatically retry and Redis commands that failed.  The caller is responsible for that.