### PR TITLE
Add FromResp impl for HashMap

### DIFF
--- a/src/resp.rs
+++ b/src/resp.rs
@@ -208,7 +208,7 @@ impl<K: FromResp + Hash + Eq, T: FromResp> FromResp for HashMap<K, T> {
 
                 Ok(map)
             }
-            _ => Err(error::resp("Cannot be converted into a vector", resp)),
+            _ => Err(error::resp("Cannot be converted into a hashmap", resp)),
         }
     }
 }

--- a/src/resp.rs
+++ b/src/resp.rs
@@ -194,23 +194,14 @@ impl<K: FromResp + Hash + Eq, T: FromResp> FromResp for HashMap<K, T> {
         match resp {
             RespValue::Array(ary) => {
                 let mut map = HashMap::new();
-                let mut items = ary.into_iter().peekable();
+                let mut items = ary.into_iter();
 
-                loop {
-                    if items.peek().is_none() {
-                        break;
-                    }
-
-                    let key = K::from_resp(
-                        items
-                            .next()
-                            .ok_or(error::resp("Cannot be converted into a hashmap", "".into()))?,
-                    )?;
-                    let value = T::from_resp(
-                        items
-                            .next()
-                            .ok_or(error::resp("Cannot be converted into a hashmap", "".into()))?,
-                    )?;
+                while let Some(k) = items.next() {
+                    let key = K::from_resp(k)?;
+                    let value = T::from_resp(items.next().ok_or(error::resp(
+                        "Cannot convert odd number of elements into a hashmap",
+                        "".into(),
+                    ))?)?;
 
                     map.insert(key, value);
                 }

--- a/src/resp.rs
+++ b/src/resp.rs
@@ -10,6 +10,8 @@
 
 //! An implementation of the RESP protocol
 
+use std::hash::Hash;
+use std::collections::HashMap;
 use std::io;
 use std::str;
 
@@ -181,6 +183,31 @@ impl<T: FromResp> FromResp for Vec<T> {
                     ar.push(T::from_resp(value)?);
                 }
                 Ok(ar)
+            }
+            _ => Err(error::resp("Cannot be converted into a vector", resp)),
+        }
+    }
+}
+
+impl<K: FromResp + Hash + Eq, T: FromResp> FromResp for HashMap<K, T> {
+    fn from_resp_int(resp: RespValue) -> Result<HashMap<K, T>, Error> {
+        match resp {
+            RespValue::Array(ary) => {
+                let mut map = HashMap::new();
+                let mut items = ary.into_iter().peekable();
+
+                loop {
+                    if items.peek().is_none() {
+                        break;
+                    }
+
+                    let key = K::from_resp(items.next().ok_or(error::resp("Cannot be converted into a hashmap", "".into()))?)?;
+                    let value = T::from_resp(items.next().ok_or(error::resp("Cannot be converted into a hashmap", "".into()))?)?;
+
+                    map.insert(key, value);
+                }
+
+                Ok(map)
             }
             _ => Err(error::resp("Cannot be converted into a vector", resp)),
         }
@@ -613,11 +640,13 @@ impl Decoder for RespCodec {
 
 #[cfg(test)]
 mod tests {
+    use std::collections::HashMap;
+
     use bytes::BytesMut;
 
     use tokio_io::codec::{Decoder, Encoder};
 
-    use super::{FromResp, RespCodec, RespValue};
+    use super::{Error, FromResp, RespCodec, RespValue};
 
     #[test]
     fn test_bulk_string() {
@@ -674,5 +703,31 @@ mod tests {
     fn test_integer_convesion() {
         let resp_object = RespValue::Integer(50);
         assert_eq!(u32::from_resp(resp_object).unwrap(), 50);
+    }
+
+    #[test]
+    fn test_hashmap_conversion() {
+        let mut expected = HashMap::new();
+        expected.insert("KEY1".to_string(), "VALUE1".to_string());
+        expected.insert("KEY2".to_string(), "VALUE2".to_string());
+
+        let resp_object = RespValue::Array(vec!["KEY1".into(), "VALUE1".into(), "KEY2".into(), "VALUE2".into()]);
+        assert_eq!(HashMap::<String, String>::from_resp(resp_object).unwrap(), expected);
+    }
+
+    #[test]
+    fn test_hashmap_conversion_fails_with_uneven() {
+        let mut expected = HashMap::new();
+        expected.insert("KEY1".to_string(), "VALUE1".to_string());
+        expected.insert("KEY2".to_string(), "VALUE2".to_string());
+        expected.insert("KEY3".to_string(), "VALUE3".to_string());
+
+        let resp_object = RespValue::Array(vec!["KEY1".into(), "VALUE1".into(), "KEY2".into(), "VALUE2".into(), "KEY3".into()]);
+        let res = HashMap::<String, String>::from_resp(resp_object);
+
+        match res {
+            Err(Error::RESP(_, _)) => {},
+            _ => panic!("Converted to an uneven array of elements to a hashmap")
+        }
     }
 }

--- a/src/resp.rs
+++ b/src/resp.rs
@@ -199,7 +199,7 @@ impl<K: FromResp + Hash + Eq, T: FromResp> FromResp for HashMap<K, T> {
                 while let Some(k) = items.next() {
                     let key = K::from_resp(k)?;
                     let value = T::from_resp(items.next().ok_or(error::resp(
-                        "Cannot convert odd number of elements into a hashmap",
+                        "Cannot convert an odd number of elements into a hashmap",
                         "".into(),
                     ))?)?;
 
@@ -723,12 +723,7 @@ mod tests {
     }
 
     #[test]
-    fn test_hashmap_conversion_fails_with_uneven() {
-        let mut expected = HashMap::new();
-        expected.insert("KEY1".to_string(), "VALUE1".to_string());
-        expected.insert("KEY2".to_string(), "VALUE2".to_string());
-        expected.insert("KEY3".to_string(), "VALUE3".to_string());
-
+    fn test_hashmap_conversion_fails_with_odd_length_array() {
         let resp_object = RespValue::Array(vec![
             "KEY1".into(),
             "VALUE1".into(),
@@ -740,7 +735,7 @@ mod tests {
 
         match res {
             Err(Error::RESP(_, _)) => {}
-            _ => panic!("Converted to an uneven array of elements to a hashmap"),
+            _ => panic!("Should not be able to convert an odd number of elements to a hashmap"),
         }
     }
 }

--- a/src/resp.rs
+++ b/src/resp.rs
@@ -10,8 +10,8 @@
 
 //! An implementation of the RESP protocol
 
-use std::hash::Hash;
 use std::collections::HashMap;
+use std::hash::Hash;
 use std::io;
 use std::str;
 
@@ -201,8 +201,16 @@ impl<K: FromResp + Hash + Eq, T: FromResp> FromResp for HashMap<K, T> {
                         break;
                     }
 
-                    let key = K::from_resp(items.next().ok_or(error::resp("Cannot be converted into a hashmap", "".into()))?)?;
-                    let value = T::from_resp(items.next().ok_or(error::resp("Cannot be converted into a hashmap", "".into()))?)?;
+                    let key = K::from_resp(
+                        items
+                            .next()
+                            .ok_or(error::resp("Cannot be converted into a hashmap", "".into()))?,
+                    )?;
+                    let value = T::from_resp(
+                        items
+                            .next()
+                            .ok_or(error::resp("Cannot be converted into a hashmap", "".into()))?,
+                    )?;
 
                     map.insert(key, value);
                 }
@@ -711,8 +719,16 @@ mod tests {
         expected.insert("KEY1".to_string(), "VALUE1".to_string());
         expected.insert("KEY2".to_string(), "VALUE2".to_string());
 
-        let resp_object = RespValue::Array(vec!["KEY1".into(), "VALUE1".into(), "KEY2".into(), "VALUE2".into()]);
-        assert_eq!(HashMap::<String, String>::from_resp(resp_object).unwrap(), expected);
+        let resp_object = RespValue::Array(vec![
+            "KEY1".into(),
+            "VALUE1".into(),
+            "KEY2".into(),
+            "VALUE2".into(),
+        ]);
+        assert_eq!(
+            HashMap::<String, String>::from_resp(resp_object).unwrap(),
+            expected
+        );
     }
 
     #[test]
@@ -722,12 +738,18 @@ mod tests {
         expected.insert("KEY2".to_string(), "VALUE2".to_string());
         expected.insert("KEY3".to_string(), "VALUE3".to_string());
 
-        let resp_object = RespValue::Array(vec!["KEY1".into(), "VALUE1".into(), "KEY2".into(), "VALUE2".into(), "KEY3".into()]);
+        let resp_object = RespValue::Array(vec![
+            "KEY1".into(),
+            "VALUE1".into(),
+            "KEY2".into(),
+            "VALUE2".into(),
+            "KEY3".into(),
+        ]);
         let res = HashMap::<String, String>::from_resp(resp_object);
 
         match res {
-            Err(Error::RESP(_, _)) => {},
-            _ => panic!("Converted to an uneven array of elements to a hashmap")
+            Err(Error::RESP(_, _)) => {}
+            _ => panic!("Converted to an uneven array of elements to a hashmap"),
         }
     }
 }


### PR DESCRIPTION
This PR adds an implementation of FromResp for HashMap. It takes an array response containing an even number of elements and treats it as a list of alternating key, value elements.

```
KEY1
VALUE1
KEY2
VALUE2
```

This can be used to transform the response of HGETALL into a HashMap<K, V> where K and V implement FromResp.

Not sure if this is in scope for this library, but here it is in case others find it useful.

Ran in to this in an exercise to try porting an existing project from redis-rs to redis-async-rs. Heavily inspired by https://docs.rs/redis/0.9.1/src/redis/types.rs.html#844-860