### PR TITLE
fix breakage caused by impl From<&String> for String

### DIFF
--- a/src/client/pubsub.rs
+++ b/src/client/pubsub.rs
@@ -291,6 +291,7 @@ impl Stream for PubsubStream {
 
 impl Drop for PubsubStream {
     fn drop(&mut self) {
-        self.con.unsubscribe(self.topic.as_ref());
+        let topic: &str = self.topic.as_ref();
+        self.con.unsubscribe(topic);
     }
 }


### PR DESCRIPTION
`From<&String> for String` was [merged](https://github.com/rust-lang/rust/pull/59825) into `nightly` recently. Current `master` [fails](https://travis-ci.org/benashford/redis-async-rs/jobs/534553273) on CI with: 
```
type annotations required: cannot resolve `std::string::String: std::convert::AsRef<_>`
```
error.
I think this is one of the ways to fix it. It works for me in `stable` and latest nightly channels (`rustc 1.36.0-nightly (6afcb5628 2019-05-19)`).