### PR TITLE
Update crate for Rust 2018

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,6 +7,7 @@ readme = "README.md"
 description = "An asynchronous futures based Redis client for Rust using Tokio"
 repository = "https://github.com/benashford/redis-async-rs"
 keywords = ["redis", "tokio"]
+edition = "2018"
 
 [dependencies]
 bytes = "0.4.5"

--- a/src/client/connect.rs
+++ b/src/client/connect.rs
@@ -17,7 +17,7 @@ use tokio_codec::{Decoder, Framed};
 
 use tokio_tcp::TcpStream;
 
-use resp;
+use crate::resp;
 
 pub type RespConnection = Framed<TcpStream, resp::RespCodec>;
 

--- a/src/client/mod.rs
+++ b/src/client/mod.rs
@@ -40,8 +40,8 @@ mod test {
 
     use tokio;
 
-    use error;
-    use resp;
+    use crate::error;
+    use crate::resp;
 
     fn run_and_wait<R, E, F>(f: F) -> Result<R, E>
     where

--- a/src/client/paired.rs
+++ b/src/client/paired.rs
@@ -21,9 +21,9 @@ use futures::{
 use tokio_executor::{DefaultExecutor, Executor};
 
 use super::connect::{connect, RespConnection};
-use error;
-use reconnect::{reconnect, Reconnect};
-use resp;
+use crate::error;
+use crate::reconnect::{reconnect, Reconnect};
+use crate::resp;
 
 enum SendStatus {
     Ok,

--- a/src/client/pubsub.rs
+++ b/src/client/pubsub.rs
@@ -21,9 +21,9 @@ use futures::{
 use tokio_executor::{DefaultExecutor, Executor};
 
 use super::connect::{connect, RespConnection};
-use error;
-use reconnect::{reconnect, Reconnect};
-use resp::{self, FromResp};
+use crate::error;
+use crate::reconnect::{reconnect, Reconnect};
+use crate::resp::{self, FromResp};
 
 #[derive(Debug)]
 enum PubsubEvent {

--- a/src/error.rs
+++ b/src/error.rs
@@ -14,7 +14,7 @@ use std::{error, fmt, io};
 
 use futures::sync::{mpsc, oneshot};
 
-use resp;
+use crate::resp;
 
 #[derive(Debug)]
 pub enum Error {


### PR DESCRIPTION
Update crate for Rust 2018 using 'cargo fix --edition'