### PR TITLE
Solve compilation failure

### DIFF
--- a/src/client/pubsub.rs
+++ b/src/client/pubsub.rs
@@ -19,9 +19,9 @@ use std::{
 
 use futures_channel::{mpsc, oneshot};
 use futures_util::{
-    sink::Sink,
     stream::{Fuse, Stream, StreamExt},
 };
+use futures_sink::Sink;
 
 use super::connect::{connect, RespConnection};
 


### PR DESCRIPTION
redis-async = "0.6.0"
tokio = "0.2.1"
toolchain: nightly-x86_64-pc-windows-gnu 1.41.0-nightly (412f43ac5 2019-11-24)
error:
error[E0432]: unresolved import futures_util::sink
--> C:\Users\lsong.cargo\registry\src\github.com-1ecc6299db9ec823\redis-async-0.6.0\src\client\pubsub.rs:22:5
|
22 | sink::Sink,
| ^^^^ could not find sink in futures_util

error[E0599]: no method named poll_ready found for type std::pin::Pin<&mut tokio_util::codec::framed::Framed<tokio::net::tcp::stream::TcpStream, resp::RespCodec>> in the current scope
--> C:\Users\lsong.cargo\registry\src\github.com-1ecc6299db9ec823\redis-async-0.6.0\src\client\pubsub.rs:75:46
|
75 | match Pin::new(&mut self.connection).poll_ready(cx) {
| ^^^^^^^^^^ method not found in std::pin::Pin<&mut tokio_util::codec::framed::Framed<tokio::net::tcp::stream::TcpStream, resp::RespCodec>>
|
= help: items from traits can only be used if the trait is in scope
= note: the following trait is implemented but not in scope; perhaps add a use for it:
use futures_sink::Sink;

error[E0599]: no method named start_send found for type std::pin::Pin<&mut tokio_util::codec::framed::Framed<tokio::net::tcp::stream::TcpStream, resp::RespCodec>> in the current scope
--> C:\Users\lsong.cargo\registry\src\github.com-1ecc6299db9ec823\redis-async-0.6.0\src\client\pubsub.rs:77:48
|
77 | Pin::new(&mut self.connection).start_send(msg)?;
| ^^^^^^^^^^ method not found in std::pin::Pin<&mut tokio_util::codec::framed::Framed<tokio::net::tcp::stream::TcpStream, resp::RespCodec>>
|
= help: items from traits can only be used if the trait is in scope
= note: the following trait is implemented but not in scope; perhaps add a use for it:
use futures_sink::Sink;

error[E0599]: no method named poll_flush found for type std::pin::Pin<&mut tokio_util::codec::framed::Framed<tokio::net::tcp::stream::TcpStream, resp::RespCodec>> in the current scope
--> C:\Users\lsong.cargo\registry\src\github.com-1ecc6299db9ec823\redis-async-0.6.0\src\client\pubsub.rs:88:46
|
88 | match Pin::new(&mut self.connection).poll_flush(cx) {
| ^^^^^^^^^^ method not found in std::pin::Pin<&mut tokio_util::codec::framed::Framed<tokio::net::tcp::stream::TcpStream, resp::RespCodec>>
|
= help: items from traits can only be used if the trait is in scope
= note: the following trait is implemented but not in scope; perhaps add a use for it:
use futures_sink::Sink;

error: aborting due to 4 previous errors

Some errors have detailed explanations: E0432, E0599.
For more information about an error, try rustc --explain E0432.
error: could not compile redis-async.