### PR TITLE
Remove deprecated Error::description and Error::cause

### DIFF
--- a/src/client/pubsub.rs
+++ b/src/client/pubsub.rs
@@ -18,10 +18,8 @@ use std::{
 };
 
 use futures_channel::{mpsc, oneshot};
-use futures_util::{
-    stream::{Fuse, Stream, StreamExt},
-};
 use futures_sink::Sink;
+use futures_util::stream::{Fuse, Stream, StreamExt};
 
 use super::connect::{connect, RespConnection};
 

--- a/src/resp.rs
+++ b/src/resp.rs
@@ -16,7 +16,7 @@ use std::{
     io, str,
 };
 
-use bytes::{BufMut, BytesMut};
+use bytes::{Buf, BufMut, BytesMut};
 
 use tokio_util::codec::{Decoder, Encoder};
 
@@ -645,7 +645,7 @@ impl Decoder for RespCodec {
         match decode(buf, 0) {
             Ok(None) => Ok(None),
             Ok(Some((pos, item))) => {
-                buf.split_to(pos);
+                buf.advance(pos);
                 Ok(Some(item))
             }
             Err(e) => Err(e),


### PR DESCRIPTION
`Error::description` and `Error::cause` are deprecated in favor of `Display` and `Error::source`.
https://doc.rust-lang.org/std/error/trait.Error.html#method.description

This PR also includes formatting and a fix for tokio warning. 

