### PR TITLE
Auth

### DIFF
--- a/src/client/mod.rs
+++ b/src/client/mod.rs
@@ -27,6 +27,6 @@ pub mod pubsub;
 
 pub use self::{
     connect::connect,
-    paired::{paired_connect, PairedConnection},
+    paired::{paired_connect, PairedConnection, PairedConnectionBuilder},
     pubsub::{pubsub_connect, PubsubConnection},
 };

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -60,4 +60,4 @@ pub mod client;
 
 pub mod error;
 
-pub mod reconnect;
+pub(crate) mod reconnect;

--- a/src/resp.rs
+++ b/src/resp.rs
@@ -71,6 +71,19 @@ impl RespValue {
         }
         self
     }
+
+    /// Push item to Resp array
+    ///
+    /// This will panic if called for anything other than arrays
+    pub fn push<T : Into<RespValue>>(&mut self, item: T)
+    {
+        match self {
+            RespValue::Array(ref mut vals) => {
+                vals.push(item.into());
+            }
+            _ => panic!("Can only push to arrays"),
+        }
+    }
 }
 
 /// A trait to be implemented for every time which can be read from a RESP value.


### PR DESCRIPTION
While it is possible to authenticate with redis using the current interface, it is somewhat tricky to get right, as one has to remember to send yet another AUTH command before repeating the failed command when an connection error occurs.  It would make some sense for the library to do this. 

This adds a PairedConnectionBuilder that accepts a username and password.
Whenever the connection is reestablished an AUTH command is send, and the response inspected before other commands are send.

I have not done too much witch documentation and such yet. I first want to hear if this is a feature that you think it makes sense add, and if yes, if this is the right approach to do it, or if there is some other path I should have taken.