### PR TITLE
Release 0 8

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -1,0 +1,45 @@
+on: [push, pull_request]
+
+name: Continuous integration
+
+jobs:
+  ci:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        rust:
+          - stable
+          - beta
+          - nightly
+
+    steps:
+      - uses: actions/checkout@v2
+
+      - uses: actions-rs/toolchain@v1
+        with:
+          profile: minimal
+          toolchain: ${{ matrix.rust }}
+          override: true
+          components: rustfmt, clippy
+
+      - uses: supercharge/redis-github-action@1.1.0
+        with:
+          redis-version: 6
+
+      - uses: actions-rs/cargo@v1
+        with:
+          command: build
+
+      - uses: actions-rs/cargo@v1
+        with:
+          command: test
+
+      - uses: actions-rs/cargo@v1
+        with:
+          command: fmt
+          args: --all -- --check
+
+      - uses: actions-rs/cargo@v1
+        with:
+          command: clippy
+          args: -- -D warnings

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,0 @@
-language: rust
-services:
-  - redis-server
-rust:
-  - stable
-  - beta
-  - nightly

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "redis-async"
-version = "0.7.3"
+version = "0.7.4"
 authors = ["Ben Ashford <benashford@users.noreply.github.com>"]
 license = "MIT/Apache-2.0"
 readme = "README.md"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "redis-async"
-version = "0.7.4"
+version = "0.8.0"
 authors = ["Ben Ashford <benashford@users.noreply.github.com>"]
 license = "MIT/Apache-2.0"
 readme = "README.md"
@@ -10,15 +10,25 @@ keywords = ["redis", "tokio"]
 edition = "2018"
 
 [dependencies]
-bytes = "^0.6.0"
+bytes_05 = { package = "bytes", version = "0.5", optional = true }
+bytes_06 = { package = "bytes", version = "^0.6.0", optional = true }
 log = "^0.4.11"
 futures-channel = "^0.3.7"
 futures-sink = "^0.3.7"
 futures-util = "^0.3.7"
-tokio = { version = "^0.3.2", features = ["net", "time"] }
-tokio-util = { version = "^0.5", features = ["codec"] }
+tokio_02 = { package = "tokio", version = "0.2", features = ["rt-core", "net", "time"], optional = true}
+tokio_03 = { package = "tokio", version = "^0.3.2", features = ["rt", "net", "time"], optional = true }
+tokio-util_03 = { package = "tokio-util", version = "0.3", features = ["codec"], optional = true }
+tokio-util_05 = { package = "tokio-util", version = "^0.5", features = ["codec"], optional = true }
 
 [dev-dependencies]
 env_logger = "^0.8.1"
 futures = "^0.3.7"
-tokio = { version = "^0.3.2", features = ["full"] }
+tokio_02 = { package = "tokio", version = "0.2", features = ["full"] }
+tokio_03 = { package = "tokio", version = "^0.3.2", features = ["full"] }
+
+[features]
+default = ["tokio03"]
+
+tokio03 = ["bytes_06", "tokio_03", "tokio-util_05"]
+tokio02 = ["bytes_05", "tokio_02", "tokio-util_03"]

--- a/README.md
+++ b/README.md
@@ -20,9 +20,11 @@ Version 0.5 introduces minor changes to error handling, and reconnect behaviour 
 
 In summary: a `PairedConnection` or `PubsubConnection` will remain valid and will attempt to reconnect when a connection drops (however, if a `PubsubConnection` drops, applications will need to re-subscribe). If a connection does drop, re-connection occurs in the background, calls to the connection in the meantime will error with `Error::Connection` the details will explain why, including if a reconnection failed. Clients should retry until connection succeeds in accordance with the needs of the particular application.
 
-### Minimum rustc version
+Version 0.8 contains minor refactoring with an obvious upgrade path.
 
-Version 0.6 requires rustc 1.39.0 or higher.
+### Tokio compatibility
+
+Version 0.8 supports both Tokio 0.3 and Tokio 0.2 (because many other libraries are Tokio 0.2 only still). Tokio 0.3 is the default. To enable Tokio 0.2: disable default features and enable `tokio02`.
 
 ## Other clients
 

--- a/examples/monitor.rs
+++ b/examples/monitor.rs
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2019 Ben Ashford
+ * Copyright 2017-2020 Ben Ashford
  *
  * Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
  * http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
@@ -7,6 +7,12 @@
  * option. This file may not be copied, modified, or distributed
  * except according to those terms.
  */
+
+#[cfg(feature = "tokio02")]
+extern crate tokio_02 as tokio;
+
+#[cfg(feature = "tokio03")]
+extern crate tokio_03 as tokio;
 
 use std::env;
 

--- a/examples/psubscribe.rs
+++ b/examples/psubscribe.rs
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2019 Ben Ashford
+ * Copyright 2017-2020 Ben Ashford
  *
  * Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
  * http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
@@ -7,6 +7,12 @@
  * option. This file may not be copied, modified, or distributed
  * except according to those terms.
  */
+
+#[cfg(feature = "tokio02")]
+extern crate tokio_02 as tokio;
+
+#[cfg(feature = "tokio03")]
+extern crate tokio_03 as tokio;
 
 use std::env;
 
@@ -24,7 +30,7 @@ async fn main() {
         .parse()
         .unwrap();
 
-    let pubsub_con = client::pubsub_connect(&addr)
+    let pubsub_con = client::pubsub_connect(addr)
         .await
         .expect("Cannot connect to Redis");
     let mut msgs = pubsub_con

--- a/examples/realistic.rs
+++ b/examples/realistic.rs
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2019 Ben Ashford
+ * Copyright 2017-2020 Ben Ashford
  *
  * Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
  * http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
@@ -7,6 +7,12 @@
  * option. This file may not be copied, modified, or distributed
  * except according to those terms.
  */
+
+#[cfg(feature = "tokio02")]
+extern crate tokio_02 as tokio;
+
+#[cfg(feature = "tokio03")]
+extern crate tokio_03 as tokio;
 
 use std::env;
 
@@ -29,7 +35,7 @@ async fn main() {
         .parse()
         .unwrap();
 
-    let connection = client::paired_connect(&addr)
+    let connection = client::paired_connect(addr)
         .await
         .expect("Cannot open connection");
 

--- a/examples/subscribe.rs
+++ b/examples/subscribe.rs
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2019 Ben Ashford
+ * Copyright 2017-2020 Ben Ashford
  *
  * Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
  * http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
@@ -7,6 +7,12 @@
  * option. This file may not be copied, modified, or distributed
  * except according to those terms.
  */
+
+#[cfg(feature = "tokio02")]
+extern crate tokio_02 as tokio;
+
+#[cfg(feature = "tokio03")]
+extern crate tokio_03 as tokio;
 
 use std::env;
 
@@ -26,7 +32,7 @@ async fn main() {
         .parse()
         .unwrap();
 
-    let pubsub_con = client::pubsub_connect(&addr)
+    let pubsub_con = client::pubsub_connect(addr)
         .await
         .expect("Cannot connect to Redis");
     let mut msgs = pubsub_con

--- a/src/client/builder.rs
+++ b/src/client/builder.rs
@@ -1,0 +1,49 @@
+/*
+ * Copyright 2020 Ben Ashford
+ *
+ * Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+ * http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+ * <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+ * option. This file may not be copied, modified, or distributed
+ * except according to those terms.
+ */
+
+use std::net::{SocketAddr, ToSocketAddrs};
+use std::sync::Arc;
+
+use crate::error;
+
+#[derive(Debug)]
+/// Connection builder
+pub struct ConnectionBuilder {
+    pub(crate) addr: SocketAddr,
+    pub(crate) username: Option<Arc<str>>,
+    pub(crate) password: Option<Arc<str>>,
+}
+
+impl ConnectionBuilder {
+    pub fn new<A: ToSocketAddrs>(addr: A) -> Result<Self, error::Error> {
+        Ok(Self {
+            addr: addr
+                .to_socket_addrs()?
+                .next()
+                .ok_or(error::Error::Connection(
+                    error::ConnectionReason::ConnectionFailed,
+                ))?,
+            username: None,
+            password: None,
+        })
+    }
+
+    /// Set the username used when connecting
+    pub fn password<V: Into<Arc<str>>>(&mut self, password: V) -> &mut Self {
+        self.password = Some(password.into());
+        self
+    }
+
+    /// Set the password used when connecting
+    pub fn username<V: Into<Arc<str>>>(&mut self, username: V) -> &mut Self {
+        self.username = Some(username.into());
+        self
+    }
+}

--- a/src/client/mod.rs
+++ b/src/client/mod.rs
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2019 Ben Ashford
+ * Copyright 2017-2020 Ben Ashford
  *
  * Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
  * http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
@@ -23,10 +23,12 @@
 pub mod connect;
 #[macro_use]
 pub mod paired;
+mod builder;
 pub mod pubsub;
 
 pub use self::{
+    builder::ConnectionBuilder,
     connect::connect,
-    paired::{paired_connect, PairedConnection, PairedConnectionBuilder},
+    paired::{paired_connect, PairedConnection},
     pubsub::{pubsub_connect, PubsubConnection},
 };

--- a/src/client/pubsub.rs
+++ b/src/client/pubsub.rs
@@ -353,7 +353,7 @@ pub async fn pubsub_connect(addr: &SocketAddr) -> Result<PubsubConnection, error
         },
         move || {
             let con_f = inner_conn_fn(addr);
-            Box::new(Box::pin(con_f))
+            Box::pin(con_f)
         },
     );
     Ok(PubsubConnection {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2019 Ben Ashford
+ * Copyright 2017-2020 Ben Ashford
  *
  * Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
  * http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
@@ -52,6 +52,21 @@
 //! [`subscribe`](client/pubsub/struct.PubsubConnection.html#method.subscribe) function that takes a topic as a parameter and
 //! returns a future which, once the subscription is confirmed, resolves to a stream that contains all messages published
 //! to that topic.
+
+#[cfg(feature = "tokio02")]
+extern crate bytes_05 as bytes;
+#[cfg(feature = "tokio02")]
+extern crate tokio_02 as tokio;
+#[cfg(feature = "tokio02")]
+extern crate tokio_util_03 as tokio_util;
+
+#[cfg(feature = "tokio03")]
+extern crate bytes_06 as bytes;
+#[cfg(feature = "tokio03")]
+extern crate tokio_03 as tokio;
+#[cfg(feature = "tokio03")]
+extern crate tokio_util_05 as tokio_util;
+
 #[macro_use]
 pub mod resp;
 

--- a/src/resp.rs
+++ b/src/resp.rs
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2019 Ben Ashford
+ * Copyright 2017-2020 Ben Ashford
  *
  * Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
  * http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
@@ -10,11 +10,11 @@
 
 //! An implementation of the RESP protocol
 
-use std::{
-    collections::HashMap,
-    hash::{BuildHasher, Hash},
-    io, str,
-};
+use std::collections::HashMap;
+use std::hash::{BuildHasher, Hash};
+use std::io;
+use std::str;
+use std::sync::Arc;
 
 use bytes::{Buf, BufMut, BytesMut};
 
@@ -75,8 +75,7 @@ impl RespValue {
     /// Push item to Resp array
     ///
     /// This will panic if called for anything other than arrays
-    pub fn push<T : Into<RespValue>>(&mut self, item: T)
-    {
+    pub fn push<T: Into<RespValue>>(&mut self, item: T) {
         match self {
             RespValue::Array(ref mut vals) => {
                 vals.push(item.into());
@@ -396,6 +395,13 @@ impl ToRespString for Vec<u8> {
     }
 }
 string_into_resp!(Vec<u8>);
+
+impl ToRespString for Arc<str> {
+    fn to_resp_string(self) -> RespValue {
+        RespValue::BulkString(self.as_bytes().into())
+    }
+}
+string_into_resp!(Arc<str>);
 
 pub trait ToRespInteger {
     fn to_resp_integer(self) -> RespValue;

--- a/src/resp.rs
+++ b/src/resp.rs
@@ -624,6 +624,7 @@ fn decode_integer(buf: &mut BytesMut, idx: usize) -> DecodeResult {
 }
 
 /// A simple string is any series of bytes that ends with `\r\n`
+#[allow(clippy::unknown_clippy_lints, clippy::unnecessary_wraps)]
 fn decode_simple_string(buf: &mut BytesMut, idx: usize) -> DecodeResult {
     match scan_string(buf, idx) {
         None => Ok(None),
@@ -631,6 +632,7 @@ fn decode_simple_string(buf: &mut BytesMut, idx: usize) -> DecodeResult {
     }
 }
 
+#[allow(clippy::unknown_clippy_lints, clippy::unnecessary_wraps)]
 fn decode_error(buf: &mut BytesMut, idx: usize) -> DecodeResult {
     match scan_string(buf, idx) {
         None => Ok(None),


### PR DESCRIPTION
This includes #63 as well as some refactoring any tiny (technically breaking) changes hence the bump to 0.8.

0.8 also supports Tokio 0.2 and 0.3, this avoids the need to maintain the 0.6 branch as a Tokio 0.2 branch. I expect this will be a very short-lived feature as Tokio 1.0 will be released soon, but some people may require Tokio 0.2 compatibility for a while as other Tokio libraries are slower to update.