### PR TITLE
Report errors better

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "redis-async"
-version = "0.9.2"
+version = "0.10.0"
 authors = ["Ben Ashford <benashford@users.noreply.github.com>"]
 license = "MIT/Apache-2.0"
 readme = "README.md"

--- a/src/client/paired.rs
+++ b/src/client/paired.rs
@@ -166,7 +166,6 @@ impl PairedConnectionInner {
             ))));
         }
 
-        // TODO - this could be handled better, returning errors to waiting things, possibly.
         log::error!("Internal error in PairedConnectionInner: {}", e);
     }
 }

--- a/src/client/paired.rs
+++ b/src/client/paired.rs
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2020 Ben Ashford
+ * Copyright 2017-2021 Ben Ashford
  *
  * Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
  * http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
@@ -56,7 +56,8 @@ enum ReceiveStatus {
     NotReady,
 }
 
-type Responder = oneshot::Sender<resp::RespValue>;
+type CommandResult = Result<resp::RespValue, error::Error>;
+type Responder = oneshot::Sender<CommandResult>;
 type SendPayload = (resp::RespValue, Responder);
 
 // /// The PairedConnectionInner is a spawned future that is responsible for pairing commands and
@@ -76,7 +77,7 @@ struct PairedConnectionInner {
 impl PairedConnectionInner {
     fn new(
         con: RespConnection,
-        out_rx: mpsc::UnboundedReceiver<(resp::RespValue, oneshot::Sender<resp::RespValue>)>,
+        out_rx: mpsc::UnboundedReceiver<(resp::RespValue, Responder)>,
     ) -> Self {
         PairedConnectionInner {
             connection: con,
@@ -144,19 +145,27 @@ impl PairedConnectionInner {
         }
         match self.connection.poll_next_unpin(cx) {
             Poll::Ready(None) => Err(error::unexpected("Connection to Redis closed unexpectedly")),
-            Poll::Ready(Some(msg)) => {
+            Poll::Ready(Some(Ok(msg))) => {
                 let tx = match self.waiting.pop_front() {
                     Some(tx) => tx,
                     None => panic!("Received unexpected message: {:?}", msg),
                 };
-                let _ = tx.send(msg?);
+                let _ = tx.send(Ok(msg));
                 Ok(ReceiveStatus::ReadyMore)
             }
+            Poll::Ready(Some(Err(e))) => Err(e),
             Poll::Pending => Ok(ReceiveStatus::NotReady),
         }
     }
 
-    fn handle_error(&self, e: &error::Error) {
+    fn handle_error(&mut self, e: &error::Error) {
+        for tx in self.waiting.drain(..) {
+            let _ = tx.send(Err(error::internal(format!(
+                "Failed due to underlying failure: {}",
+                e
+            ))));
+        }
+
         // TODO - this could be handled better, returning errors to waiting things, possibly.
         log::error!("Internal error in PairedConnectionInner: {}", e);
     }
@@ -280,7 +289,8 @@ impl PairedConnection {
         match self.out_tx_c.do_work((msg, tx)) {
             Ok(()) => future::Either::Left(async move {
                 match rx.await {
-                    Ok(v) => Ok(T::from_resp(v)?),
+                    Ok(Ok(v)) => Ok(T::from_resp(v)?),
+                    Ok(Err(e)) => Err(e),
                     Err(_) => Err(error::internal(
                         "Connection closed before response received",
                     )),

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2019 Ben Ashford
+ * Copyright 2017-2021 Ben Ashford
  *
  * Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
  * http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
@@ -25,7 +25,7 @@ pub enum Error {
     IO(io::Error),
 
     /// A RESP parsing/serialising error occurred
-    RESP(String, Option<resp::RespValue>),
+    Resp(String, Option<resp::RespValue>),
 
     /// A remote error
     Remote(String),
@@ -52,7 +52,7 @@ pub(crate) fn unexpected(msg: impl Into<String>) -> Error {
 }
 
 pub(crate) fn resp(msg: impl Into<String>, resp: resp::RespValue) -> Error {
-    Error::RESP(msg.into(), Some(resp))
+    Error::Resp(msg.into(), Some(resp))
 }
 
 impl From<io::Error> for Error {
@@ -81,7 +81,7 @@ impl fmt::Display for Error {
         match self {
             Error::Internal(s) => write!(f, "{}", s),
             Error::IO(err) => write!(f, "{}", err),
-            Error::RESP(s, resp) => write!(f, "{}: {:?}", s, resp),
+            Error::Resp(s, resp) => write!(f, "{}: {:?}", s, resp),
             Error::Remote(s) => write!(f, "{}", s),
             Error::Connection(ConnectionReason::Connected) => {
                 write!(f, "Connection already established")


### PR DESCRIPTION
This is a very minor, but breaking, change (hence bumping from `0.9` to `0.10`) to:

1. Fix a bug where a connection error when the connection is idle would panic.
2. In the case where the connection is not idle, but an error happens, some information as to error will be communicated to any waiting tasks.

Since it's a breaking change I've also renamed a few things to ensure it follows Rust idioms as enforced by Clippy.