### PR TITLE
Resolve pubsub future only when nothing can happen anymore

### DIFF
--- a/src/client/pubsub.rs
+++ b/src/client/pubsub.rs
@@ -443,6 +443,8 @@ impl PubsubConnection {
 pub struct PubsubStream {
     topic: String,
     underlying: PubsubStreamInner,
+    // Note that, to keep the Future running, PubsubConnectionInner relies on PubsubStream to hold
+    // a reference to the connection. If that's ever changed remember to adapt the readiness check.
     con: PubsubConnection,
 }
 


### PR DESCRIPTION
With these changes `PubsubConnectionInner` should complete only if every `PubsubConnection` have been dropped.

It should be enough to guarantee that:
- there are no open subscriptions (`PubsubStream` keeps a reference to `PubsubConnection` and unsubscribes when dropped)
- there's no one waiting on pending subscriptions (the promise keeps a reference to `PubsubConnection`)
- no one will subscribe again (you need a `PubsubConnection` to do that)

Fixes #50 