### PR TITLE
Give Tokio the thing to resolve, rather than the resolved address, th…

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "redis-async"
-version = "0.11.0"
+version = "0.12.0"
 authors = ["Ben Ashford <benashford@users.noreply.github.com>"]
 license = "MIT/Apache-2.0"
 readme = "README.md"
@@ -22,7 +22,7 @@ tokio-util_03 = { package = "tokio-util", version = "0.3", features = ["codec"],
 tokio-util_06 = { package = "tokio-util", version = "0.6", features = ["codec"], optional = true }
 
 [dev-dependencies]
-env_logger = "^0.8.1"
+env_logger = "^0.9"
 futures = "^0.3.7"
 tokio_02 = { package = "tokio", version = "0.2", features = ["full"] }
 tokio_10 = { package = "tokio", version = "1.0", features = ["full"] }

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ Version 0.8 contains minor refactoring with an obvious upgrade path.
 
 ### Tokio compatibility
 
-Version 0.8 supports both Tokio 0.3 and Tokio 0.2 (because many other libraries are Tokio 0.2 only still). Tokio 0.3 is the default. To enable Tokio 0.2: disable default features and enable `tokio02`.
+Tokio 1.0 is the default. Backward compatibility for Tokio 0.2 is available by disabling default features and enabling `tokio02`.
 
 ## Other clients
 
@@ -116,7 +116,6 @@ I've removed the benchmarks from this project, as the examples were all out-of-d
 ## Next steps
 
 - Better documentation
-- Support for `PSUBSCRIBE` as well as `SUBSCRIBE`
 - Test all Redis commands
 - Decide on best way of supporting [Redis transactions](https://redis.io/topics/transactions)
 - Decide on best way of supporting blocking Redis commands

--- a/examples/monitor.rs
+++ b/examples/monitor.rs
@@ -24,9 +24,7 @@ use redis_async::{client, resp_array};
 async fn main() {
     let addr = env::args()
         .nth(1)
-        .unwrap_or_else(|| "127.0.0.1:6379".to_string())
-        .parse()
-        .expect("Cannot parse Redis connection string");
+        .unwrap_or_else(|| "127.0.0.1:6379".to_string());
 
     let mut connection = client::connect(&addr)
         .await

--- a/examples/psubscribe.rs
+++ b/examples/psubscribe.rs
@@ -26,9 +26,7 @@ async fn main() {
     let topic = env::args().nth(1).unwrap_or_else(|| "test.*".to_string());
     let addr = env::args()
         .nth(2)
-        .unwrap_or_else(|| "127.0.0.1:6379".to_string())
-        .parse()
-        .unwrap();
+        .unwrap_or_else(|| "127.0.0.1:6379".to_string());
 
     let pubsub_con = client::pubsub_connect(addr)
         .await

--- a/examples/realistic.rs
+++ b/examples/realistic.rs
@@ -31,9 +31,7 @@ async fn main() {
 
     let addr = env::args()
         .nth(1)
-        .unwrap_or_else(|| "127.0.0.1:6379".to_string())
-        .parse()
-        .unwrap();
+        .unwrap_or_else(|| "127.0.0.1:6379".to_string());
 
     let connection = client::paired_connect(addr)
         .await

--- a/examples/subscribe.rs
+++ b/examples/subscribe.rs
@@ -28,9 +28,7 @@ async fn main() {
         .unwrap_or_else(|| "test-topic".to_string());
     let addr = env::args()
         .nth(2)
-        .unwrap_or_else(|| "127.0.0.1:6379".to_string())
-        .parse()
-        .unwrap();
+        .unwrap_or_else(|| "127.0.0.1:6379".to_string());
 
     let pubsub_con = client::pubsub_connect(addr)
         .await

--- a/src/client/builder.rs
+++ b/src/client/builder.rs
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 Ben Ashford
+ * Copyright 2020-2021 Ben Ashford
  *
  * Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
  * http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
@@ -8,7 +8,6 @@
  * except according to those terms.
  */
 
-use std::net::{SocketAddr, ToSocketAddrs};
 use std::sync::Arc;
 
 use crate::error;
@@ -16,20 +15,15 @@ use crate::error;
 #[derive(Debug)]
 /// Connection builder
 pub struct ConnectionBuilder {
-    pub(crate) addr: SocketAddr,
+    pub(crate) addr: String,
     pub(crate) username: Option<Arc<str>>,
     pub(crate) password: Option<Arc<str>>,
 }
 
 impl ConnectionBuilder {
-    pub fn new<A: ToSocketAddrs>(addr: A) -> Result<Self, error::Error> {
+    pub fn new(addr: impl Into<String>) -> Result<Self, error::Error> {
         Ok(Self {
-            addr: addr
-                .to_socket_addrs()?
-                .next()
-                .ok_or(error::Error::Connection(
-                    error::ConnectionReason::ConnectionFailed,
-                ))?,
+            addr: addr.into(),
             username: None,
             password: None,
         })


### PR DESCRIPTION
…is means it's refreshed automatically when reconnections occur