### PR TITLE
Add TLS support

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "redis-async"
-version = "0.13.0"
+version = "0.14.0"
 authors = ["Ben Ashford <benashford@users.noreply.github.com>"]
 license = "MIT/Apache-2.0"
 readme = "README.md"
@@ -17,6 +17,13 @@ futures-sink = "^0.3.7"
 futures-util = { version = "^0.3.7", features = ["sink"] }
 tokio = { version = "1.0", features = ["rt", "net", "time"] }
 tokio-util = { version = "0.7", features = ["codec"] }
+tokio-rustls = {version = "0.23.4", optional = true }
+webpki-roots = {version = "0.22.5", optional = true }
+
+[features]
+default = []
+tls = ["tokio-rustls", "webpki-roots", "tokio/net"]
+
 
 [dev-dependencies]
 env_logger = "^0.9"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,6 +19,7 @@ tokio = { version = "1.0", features = ["rt", "net", "time"] }
 tokio-util = { version = "0.7", features = ["codec"] }
 tokio-rustls = {version = "0.23.4", optional = true }
 webpki-roots = {version = "0.22.5", optional = true }
+pin-project = "1.0"
 
 [features]
 default = []

--- a/examples/monitor.rs
+++ b/examples/monitor.rs
@@ -18,11 +18,18 @@ use redis_async::{client, resp_array};
 async fn main() {
     let addr = env::args()
         .nth(1)
-        .unwrap_or_else(|| "127.0.0.1:6379".to_string());
+        .unwrap_or_else(|| "127.0.0.1".to_string());
 
-    let mut connection = client::connect(&addr)
+    #[cfg(not(feature = "tls"))]
+    let mut connection = client::connect(&addr, 6379)
         .await
         .expect("Cannot connect to Redis");
+
+    #[cfg(feature = "tls")]
+    let mut connection = client::connect_tls(&addr, 6379)
+        .await
+        .expect("Cannot connect to Redis");
+
     connection
         .send(resp_array!["MONITOR"])
         .await

--- a/examples/psubscribe.rs
+++ b/examples/psubscribe.rs
@@ -20,9 +20,9 @@ async fn main() {
     let topic = env::args().nth(1).unwrap_or_else(|| "test.*".to_string());
     let addr = env::args()
         .nth(2)
-        .unwrap_or_else(|| "127.0.0.1:6379".to_string());
+        .unwrap_or_else(|| "127.0.0.1".to_string());
 
-    let pubsub_con = client::pubsub_connect(addr)
+    let pubsub_con = client::pubsub_connect(addr, 6379)
         .await
         .expect("Cannot connect to Redis");
     let mut msgs = pubsub_con

--- a/examples/realistic.rs
+++ b/examples/realistic.rs
@@ -24,9 +24,9 @@ async fn main() {
 
     let addr = env::args()
         .nth(1)
-        .unwrap_or_else(|| "127.0.0.1:6379".to_string());
+        .unwrap_or_else(|| "127.0.0.1".to_string());
 
-    let connection = client::paired_connect(addr)
+    let connection = client::paired_connect(addr, 6379)
         .await
         .expect("Cannot open connection");
 

--- a/examples/subscribe.rs
+++ b/examples/subscribe.rs
@@ -22,9 +22,9 @@ async fn main() {
         .unwrap_or_else(|| "test-topic".to_string());
     let addr = env::args()
         .nth(2)
-        .unwrap_or_else(|| "127.0.0.1:6379".to_string());
+        .unwrap_or_else(|| "127.0.0.1".to_string());
 
-    let pubsub_con = client::pubsub_connect(addr)
+    let pubsub_con = client::pubsub_connect(addr, 6379)
         .await
         .expect("Cannot connect to Redis");
     let mut msgs = pubsub_con

--- a/src/client/builder.rs
+++ b/src/client/builder.rs
@@ -15,15 +15,17 @@ use crate::error;
 #[derive(Debug)]
 /// Connection builder
 pub struct ConnectionBuilder {
-    pub(crate) addr: String,
+    pub(crate) host: String,
+    pub(crate) port: u16,
     pub(crate) username: Option<Arc<str>>,
     pub(crate) password: Option<Arc<str>>,
 }
 
 impl ConnectionBuilder {
-    pub fn new(addr: impl Into<String>) -> Result<Self, error::Error> {
+    pub fn new(host: impl Into<String>, port: u16) -> Result<Self, error::Error> {
         Ok(Self {
-            addr: addr.into(),
+            host: host.into(),
+            port,
             username: None,
             password: None,
         })

--- a/src/client/builder.rs
+++ b/src/client/builder.rs
@@ -19,6 +19,8 @@ pub struct ConnectionBuilder {
     pub(crate) port: u16,
     pub(crate) username: Option<Arc<str>>,
     pub(crate) password: Option<Arc<str>>,
+    #[cfg(feature = "tls")]
+    pub(crate) tls: bool,
 }
 
 impl ConnectionBuilder {
@@ -28,6 +30,8 @@ impl ConnectionBuilder {
             port,
             username: None,
             password: None,
+            #[cfg(feature = "tls")]
+            tls: false,
         })
     }
 
@@ -40,6 +44,12 @@ impl ConnectionBuilder {
     /// Set the password used when connecting
     pub fn username<V: Into<Arc<str>>>(&mut self, username: V) -> &mut Self {
         self.username = Some(username.into());
+        self
+    }
+
+    #[cfg(feature = "tls")]
+    pub fn tls(&mut self) -> &mut Self {
+        self.tls = true;
         self
     }
 }

--- a/src/client/connect.rs
+++ b/src/client/connect.rs
@@ -9,12 +9,14 @@
  */
 
 use futures_util::{SinkExt, StreamExt};
-
-use tokio::net::{TcpStream, ToSocketAddrs};
+use tokio::net::TcpStream;
 use tokio_util::codec::{Decoder, Framed};
 
 use crate::{error, resp};
 
+#[cfg(feature = "tls")]
+pub type RespConnection = Framed<tokio_rustls::client::TlsStream<TcpStream>, resp::RespCodec>;
+#[cfg(not(feature = "tls"))]
 pub type RespConnection = Framed<TcpStream, resp::RespCodec>;
 
 /// Connect to a Redis server and return a Future that resolves to a
@@ -32,17 +34,61 @@ pub type RespConnection = Framed<TcpStream, resp::RespCodec>;
 ///
 /// But since most Redis usages involve issue commands that result in one
 /// single result, this library also implements `paired_connect`.
-pub async fn connect(addr: impl ToSocketAddrs) -> Result<RespConnection, error::Error> {
-    let tcp_stream = TcpStream::connect(addr).await?;
+#[cfg(not(feature = "tls"))]
+pub async fn connect(host: &str, port: u16) -> Result<RespConnection, error::Error> {
+    let tcp_stream = TcpStream::connect((host, port)).await?;
     Ok(resp::RespCodec.framed(tcp_stream))
 }
 
+#[cfg(feature = "tls")]
+pub async fn connect_tls(host: &str, port: u16) -> Result<RespConnection, error::Error> {
+    use std::sync::Arc;
+    use tokio_rustls::{
+        rustls::{ClientConfig, OwnedTrustAnchor, RootCertStore},
+        TlsConnector,
+    };
+
+    let mut root_store = RootCertStore::empty();
+    root_store.add_server_trust_anchors(webpki_roots::TLS_SERVER_ROOTS.0.iter().map(|ta| {
+        OwnedTrustAnchor::from_subject_spki_name_constraints(
+            ta.subject,
+            ta.spki,
+            ta.name_constraints,
+        )
+    }));
+    let config = ClientConfig::builder()
+        .with_safe_defaults()
+        .with_root_certificates(root_store)
+        .with_no_client_auth();
+    let connector = TlsConnector::from(Arc::new(config));
+    let addr = tokio::net::lookup_host((host, port))
+        .await?
+        .next()
+        .ok_or(error::Error::Connection(
+            error::ConnectionReason::ConnectionFailed,
+        ))?;
+    let tcp_stream = TcpStream::connect(addr).await?;
+
+    let stream = connector
+        .connect(
+            host.try_into()
+                .map_err(|_err| error::Error::InvalidDnsName)?,
+            tcp_stream,
+        )
+        .await?;
+    Ok(resp::RespCodec.framed(stream))
+}
+
 pub async fn connect_with_auth(
-    addr: impl ToSocketAddrs,
+    host: &str,
+    port: u16,
     username: Option<&str>,
     password: Option<&str>,
 ) -> Result<RespConnection, error::Error> {
-    let mut connection = connect(addr).await?;
+    #[cfg(feature = "tls")]
+    let mut connection = connect_tls(host, port).await?;
+    #[cfg(not(feature = "tls"))]
+    let mut connection = connect(host, port).await?;
 
     if let Some(password) = password {
         let mut auth = resp_array!["AUTH"];
@@ -71,6 +117,7 @@ pub async fn connect_with_auth(
     Ok(connection)
 }
 
+#[cfg(not(feature = "tls"))]
 #[cfg(test)]
 mod test {
     use futures_util::{
@@ -82,9 +129,9 @@ mod test {
 
     #[tokio::test]
     async fn can_connect() {
-        let addr = "127.0.0.1:6379";
-
-        let mut connection = super::connect(addr).await.expect("Cannot connect");
+        let mut connection = super::connect("127.0.0.1", 6379)
+            .await
+            .expect("Cannot connect");
         connection
             .send(resp_array!["PING", "TEST"])
             .await
@@ -101,9 +148,9 @@ mod test {
 
     #[tokio::test]
     async fn complex_test() {
-        let addr = "127.0.0.1:6379";
-
-        let mut connection = super::connect(addr).await.expect("Cannot connect");
+        let mut connection = super::connect("127.0.0.1", 6379)
+            .await
+            .expect("Cannot connect");
         let mut ops = Vec::new();
         ops.push(resp_array!["FLUSH"]);
         ops.extend((0..1000).map(|i| resp_array!["SADD", "test_set", format!("VALUE: {}", i)]));

--- a/src/client/connect.rs
+++ b/src/client/connect.rs
@@ -2,9 +2,9 @@
  * Copyright 2017-2021 Ben Ashford
  *
  * Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
- * http://www.apache.org/licenses/LICENSE-2.0>inner: streamhe MIT license
+ * http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
  * <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
- * option. This file may notinner: streamopied, modified, or distributed
+ * option. This file may not be copied, modified, or distributed
  * except according to those terms.
  */
 

--- a/src/client/mod.rs
+++ b/src/client/mod.rs
@@ -26,9 +26,13 @@ pub mod paired;
 mod builder;
 pub mod pubsub;
 
+#[cfg(not(feature = "tls"))]
+pub use self::connect::connect;
+#[cfg(feature = "tls")]
+pub use self::connect::connect_tls;
+
 pub use self::{
     builder::ConnectionBuilder,
-    connect::connect,
     paired::{paired_connect, PairedConnection},
     pubsub::{pubsub_connect, PubsubConnection},
 };

--- a/src/client/mod.rs
+++ b/src/client/mod.rs
@@ -26,7 +26,6 @@ pub mod paired;
 mod builder;
 pub mod pubsub;
 
-#[cfg(not(feature = "tls"))]
 pub use self::connect::connect;
 #[cfg(feature = "tls")]
 pub use self::connect::connect_tls;

--- a/src/client/paired.rs
+++ b/src/client/paired.rs
@@ -363,7 +363,6 @@ where
     }
 }
 
-#[cfg(not(feature = "tls"))]
 #[cfg(test)]
 mod test {
     use super::ConnectionBuilder;

--- a/src/client/pubsub.rs
+++ b/src/client/pubsub.rs
@@ -485,7 +485,6 @@ impl Drop for PubsubStream {
     }
 }
 
-#[cfg(not(feature = "tls"))]
 #[cfg(test)]
 mod test {
     use futures::{try_join, StreamExt, TryStreamExt};

--- a/src/error.rs
+++ b/src/error.rs
@@ -41,9 +41,9 @@ pub enum Error {
     /// If any error is propagated this way that needs to be handled, then it should be made into
     /// a proper option.
     Unexpected(String),
-    
+
     #[cfg(feature = "tls")]
-    InvalidDnsName
+    InvalidDnsName,
 }
 
 pub(crate) fn internal(msg: impl Into<String>) -> Error {

--- a/src/error.rs
+++ b/src/error.rs
@@ -41,6 +41,9 @@ pub enum Error {
     /// If any error is propagated this way that needs to be handled, then it should be made into
     /// a proper option.
     Unexpected(String),
+    
+    #[cfg(feature = "tls")]
+    InvalidDnsName
 }
 
 pub(crate) fn internal(msg: impl Into<String>) -> Error {
@@ -92,6 +95,10 @@ impl fmt::Display for Error {
             }
             Error::Connection(ConnectionReason::NotConnected) => {
                 write!(f, "Connection has been closed")
+            }
+            #[cfg(feature = "tls")]
+            Error::InvalidDnsName => {
+                write!(f, "Invalid dns name")
             }
             Error::Unexpected(err) => write!(f, "{}", err),
         }


### PR DESCRIPTION
Allow support for connecting to TLS wrapped redis connections. Use by Embark in prod for a while when our redis pubsub was wrapped in a TLS connection.