### PR TITLE
Fix pubsub weirdness

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,6 +31,6 @@ with-native-tls = ["native-tls", "tokio-native-tls", "tls"]
 
 
 [dev-dependencies]
-env_logger = "^0.9"
+env_logger = "0.10"
 futures = "^0.3.7"
 tokio = { version = "1.0", features = ["full"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "redis-async"
-version = "0.14.2"
+version = "0.15.0"
 authors = ["Ben Ashford <benashford@users.noreply.github.com>"]
 license = "MIT/Apache-2.0"
 readme = "README.md"
@@ -19,9 +19,9 @@ native-tls = { version = "0.2", optional = true }
 pin-project = "1.0"
 tokio = { version = "1.0", features = ["rt", "net", "time"] }
 tokio-native-tls = { version = "0.3.0", optional = true }
-tokio-rustls = { version = "0.23.4", optional = true }
+tokio-rustls = { version = "0.24", optional = true }
 tokio-util = { version = "0.7", features = ["codec"] }
-webpki-roots = {version = "0.22.5", optional = true }
+webpki-roots = {version = "0.23", optional = true }
 
 [features]
 default = []

--- a/src/client/paired.rs
+++ b/src/client/paired.rs
@@ -297,6 +297,7 @@ impl PairedConnection {
         }
     }
 
+    #[inline]
     pub fn send_and_forget(&self, msg: resp::RespValue) {
         let send_f = self.send::<resp::RespValue>(msg);
         let forget_f = async {
@@ -333,6 +334,7 @@ pub struct SendFuture<T> {
 }
 
 impl<T> SendFuture<T> {
+    #[inline]
     fn new(send_type: impl Into<SendFutureType>) -> Self {
         Self {
             send_type: send_type.into(),
@@ -347,6 +349,7 @@ where
 {
     type Output = Result<T, error::Error>;
 
+    #[inline]
     fn poll(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
         match self.get_mut().send_type {
             SendFutureType::Error(ref mut e) => match e.take() {

--- a/src/client/pubsub/inner.rs
+++ b/src/client/pubsub/inner.rs
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2021 Ben Ashford
+ * Copyright 2017-2023 Ben Ashford
  *
  * Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
  * http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
@@ -11,45 +11,25 @@
 use std::collections::{btree_map::Entry, BTreeMap};
 use std::future::Future;
 use std::pin::Pin;
-use std::sync::Arc;
-use std::task::{Context, Poll};
+use std::task::Context;
+use std::task::Poll;
 
 use futures_channel::{mpsc, oneshot};
 use futures_sink::Sink;
-use futures_util::{
-    future::TryFutureExt,
-    stream::{Fuse, Stream, StreamExt},
-};
+use futures_util::stream::{Fuse, StreamExt};
 
-use super::{
-    connect::{connect_with_auth, RespConnection},
-    ConnectionBuilder,
-};
-
+use crate::resp::FromResp;
 use crate::{
+    client::connect::RespConnection,
     error::{self, ConnectionReason},
-    reconnect::{reconnect, Reconnect},
-    resp::{self, FromResp},
+    resp,
 };
 
-#[derive(Debug)]
-enum PubsubEvent {
-    /// The: topic, sink to send messages through, and a oneshot to signal subscription has
-    /// occurred.
-    Subscribe(String, PubsubSink, oneshot::Sender<()>),
-    Psubscribe(String, PubsubSink, oneshot::Sender<()>),
-    /// The name of the topic to unsubscribe from. Unsubscription will be signaled by the stream
-    /// closing without error.
-    Unsubscribe(String),
-    Punsubscribe(String),
-}
-
-type PubsubStreamInner = mpsc::UnboundedReceiver<Result<resp::RespValue, error::Error>>;
-type PubsubSink = mpsc::UnboundedSender<Result<resp::RespValue, error::Error>>;
+use super::{PubsubEvent, PubsubSink};
 
 /// A spawned future that handles a Pub/Sub connection and routes messages to streams for
 /// downstream consumption
-struct PubsubConnectionInner {
+pub(crate) struct PubsubConnectionInner {
     /// The actual Redis connection
     connection: RespConnection,
     /// A stream onto which subscription/unsubscription requests are read
@@ -65,7 +45,7 @@ struct PubsubConnectionInner {
 }
 
 impl PubsubConnectionInner {
-    fn new(con: RespConnection, out_rx: mpsc::UnboundedReceiver<PubsubEvent>) -> Self {
+    pub(crate) fn new(con: RespConnection, out_rx: mpsc::UnboundedReceiver<PubsubEvent>) -> Self {
         PubsubConnectionInner {
             connection: con,
             out_rx: out_rx.fuse(),
@@ -331,225 +311,5 @@ impl Future for PubsubConnectionInner {
         } else {
             Poll::Ready(Ok(()))
         }
-    }
-}
-
-/// A shareable reference to subscribe to PUBSUB topics
-#[derive(Debug, Clone)]
-pub struct PubsubConnection {
-    out_tx_c: Arc<Reconnect<PubsubEvent, mpsc::UnboundedSender<PubsubEvent>>>,
-}
-
-async fn inner_conn_fn(
-    // Needs to be a String for lifetime reasons
-    host: String,
-    port: u16,
-    username: Option<Arc<str>>,
-    password: Option<Arc<str>>,
-    tls: bool,
-) -> Result<mpsc::UnboundedSender<PubsubEvent>, error::Error> {
-    let username = username.as_ref().map(|u| u.as_ref());
-    let password = password.as_ref().map(|p| p.as_ref());
-
-    let connection = connect_with_auth(&host, port, username, password, tls).await?;
-    let (out_tx, out_rx) = mpsc::unbounded();
-    tokio::spawn(async {
-        match PubsubConnectionInner::new(connection, out_rx).await {
-            Ok(_) => (),
-            Err(e) => log::error!("Pub/Sub error: {:?}", e),
-        }
-    });
-    Ok(out_tx)
-}
-
-impl ConnectionBuilder {
-    pub fn pubsub_connect(&self) -> impl Future<Output = Result<PubsubConnection, error::Error>> {
-        let username = self.username.clone();
-        let password = self.password.clone();
-
-        #[cfg(feature = "tls")]
-        let tls = self.tls;
-        #[cfg(not(feature = "tls"))]
-        let tls = false;
-
-        let host = self.host.clone();
-        let port = self.port;
-
-        let reconnecting_f = reconnect(
-            |con: &mpsc::UnboundedSender<PubsubEvent>, act| {
-                con.unbounded_send(act).map_err(|e| e.into())
-            },
-            move || {
-                let con_f =
-                    inner_conn_fn(host.clone(), port, username.clone(), password.clone(), tls);
-                Box::pin(con_f)
-            },
-        );
-        reconnecting_f.map_ok(|con| PubsubConnection {
-            out_tx_c: Arc::new(con),
-        })
-    }
-}
-
-/// Used for Redis's PUBSUB functionality.
-///
-/// Returns a future that resolves to a `PubsubConnection`. The future will only resolve once the
-/// connection is established; after the intial establishment, if the connection drops for any
-/// reason (e.g. Redis server being restarted), the connection will attempt re-connect, however
-/// any subscriptions will need to be re-subscribed.
-pub async fn pubsub_connect(
-    host: impl Into<String>,
-    port: u16,
-) -> Result<PubsubConnection, error::Error> {
-    ConnectionBuilder::new(host, port)?.pubsub_connect().await
-}
-
-impl PubsubConnection {
-    /// Subscribes to a particular PUBSUB topic.
-    ///
-    /// Returns a future that resolves to a `Stream` that contains all the messages published on
-    /// that particular topic.
-    ///
-    /// The resolved stream will end with `redis_async::error::Error::EndOfStream` if the
-    /// underlying connection is lost for unexpected reasons. In this situation, clients should
-    /// `subscribe` to re-subscribe; the underlying connect will automatically reconnect. However,
-    /// clients should be aware that resubscriptions will only succeed if the underlying connection
-    /// has re-established, so multiple calls to `subscribe` may be required.
-    pub async fn subscribe(&self, topic: &str) -> Result<PubsubStream, error::Error> {
-        let (tx, rx) = mpsc::unbounded();
-        let (signal_t, signal_r) = oneshot::channel();
-        self.out_tx_c
-            .do_work(PubsubEvent::Subscribe(topic.to_owned(), tx, signal_t))?;
-
-        match signal_r.await {
-            Ok(_) => Ok(PubsubStream {
-                topic: topic.to_owned(),
-                underlying: rx,
-                con: self.clone(),
-            }),
-            Err(_) => Err(error::internal("Subscription failed, try again later...")),
-        }
-    }
-
-    pub async fn psubscribe(&self, topic: &str) -> Result<PubsubStream, error::Error> {
-        let (tx, rx) = mpsc::unbounded();
-        let (signal_t, signal_r) = oneshot::channel();
-        self.out_tx_c
-            .do_work(PubsubEvent::Psubscribe(topic.to_owned(), tx, signal_t))?;
-
-        match signal_r.await {
-            Ok(_) => Ok(PubsubStream {
-                topic: topic.to_owned(),
-                underlying: rx,
-                con: self.clone(),
-            }),
-            Err(_) => Err(error::internal("Subscription failed, try again later...")),
-        }
-    }
-
-    /// Tells the client to unsubscribe from a particular topic. This will return immediately, the
-    /// actual unsubscription will be confirmed when the stream returned from `subscribe` ends.
-    pub fn unsubscribe<T: Into<String>>(&self, topic: T) {
-        // Ignoring any results, as any errors communicating with Redis would de-facto unsubscribe
-        // anyway, and would be reported/logged elsewhere
-        let _ = self
-            .out_tx_c
-            .do_work(PubsubEvent::Unsubscribe(topic.into()));
-    }
-
-    pub fn punsubscribe<T: Into<String>>(&self, topic: T) {
-        // Ignoring any results, as any errors communicating with Redis would de-facto unsubscribe
-        // anyway, and would be reported/logged elsewhere
-        let _ = self
-            .out_tx_c
-            .do_work(PubsubEvent::Punsubscribe(topic.into()));
-    }
-}
-
-#[derive(Debug)]
-pub struct PubsubStream {
-    topic: String,
-    underlying: PubsubStreamInner,
-    con: PubsubConnection,
-}
-
-impl Stream for PubsubStream {
-    type Item = Result<resp::RespValue, error::Error>;
-
-    fn poll_next(self: Pin<&mut Self>, cx: &mut Context) -> Poll<Option<Self::Item>> {
-        self.get_mut().underlying.poll_next_unpin(cx)
-    }
-}
-
-impl Drop for PubsubStream {
-    fn drop(&mut self) {
-        let topic: &str = self.topic.as_ref();
-        self.con.unsubscribe(topic);
-    }
-}
-
-#[cfg(test)]
-mod test {
-    use futures::{try_join, StreamExt, TryStreamExt};
-
-    use crate::{client, resp};
-
-    #[tokio::test]
-    async fn subscribe_test() {
-        let paired_c = client::paired_connect("127.0.0.1", 6379);
-        let pubsub_c = super::pubsub_connect("127.0.0.1", 6379);
-        let (paired, pubsub) = try_join!(paired_c, pubsub_c).expect("Cannot connect to Redis");
-
-        let topic_messages = pubsub
-            .subscribe("test-topic")
-            .await
-            .expect("Cannot subscribe to topic");
-
-        paired.send_and_forget(resp_array!["PUBLISH", "test-topic", "test-message"]);
-        paired.send_and_forget(resp_array!["PUBLISH", "test-not-topic", "test-message-1.5"]);
-        let _: resp::RespValue = paired
-            .send(resp_array!["PUBLISH", "test-topic", "test-message2"])
-            .await
-            .expect("Cannot send to topic");
-
-        let result: Vec<_> = topic_messages
-            .take(2)
-            .try_collect()
-            .await
-            .expect("Cannot collect two values");
-
-        assert_eq!(result.len(), 2);
-        assert_eq!(result[0], "test-message".into());
-        assert_eq!(result[1], "test-message2".into());
-    }
-
-    #[tokio::test]
-    async fn psubscribe_test() {
-        let paired_c = client::paired_connect("127.0.0.1", 6379);
-        let pubsub_c = super::pubsub_connect("127.0.0.1", 6379);
-        let (paired, pubsub) = try_join!(paired_c, pubsub_c).expect("Cannot connect to Redis");
-
-        let topic_messages = pubsub
-            .psubscribe("test.*")
-            .await
-            .expect("Cannot subscribe to topic");
-
-        paired.send_and_forget(resp_array!["PUBLISH", "test.1", "test-message-1"]);
-        paired.send_and_forget(resp_array!["PUBLISH", "test.2", "test-message-2"]);
-        let _: resp::RespValue = paired
-            .send(resp_array!["PUBLISH", "test.3", "test-message-3"])
-            .await
-            .expect("Cannot send to topic");
-
-        let result: Vec<_> = topic_messages
-            .take(3)
-            .try_collect()
-            .await
-            .expect("Cannot collect two values");
-
-        assert_eq!(result.len(), 3);
-        assert_eq!(result[0], "test-message-1".into());
-        assert_eq!(result[1], "test-message-2".into());
-        assert_eq!(result[2], "test-message-3".into());
     }
 }

--- a/src/client/pubsub/mod.rs
+++ b/src/client/pubsub/mod.rs
@@ -138,6 +138,7 @@ impl PubsubConnection {
                 topic: topic.to_owned(),
                 underlying: rx,
                 con: self.clone(),
+                is_pattern: false,
             }),
             Err(_) => Err(error::internal("Subscription failed, try again later...")),
         }
@@ -154,6 +155,7 @@ impl PubsubConnection {
                 topic: topic.to_owned(),
                 underlying: rx,
                 con: self.clone(),
+                is_pattern: true,
             }),
             Err(_) => Err(error::internal("Subscription failed, try again later...")),
         }
@@ -183,6 +185,7 @@ pub struct PubsubStream {
     topic: String,
     underlying: PubsubStreamInner,
     con: PubsubConnection,
+    is_pattern: bool,
 }
 
 impl Stream for PubsubStream {
@@ -197,7 +200,11 @@ impl Stream for PubsubStream {
 impl Drop for PubsubStream {
     fn drop(&mut self) {
         let topic: &str = self.topic.as_ref();
-        self.con.unsubscribe(topic);
+        if self.is_pattern {
+            self.con.punsubscribe(topic);
+        } else {
+            self.con.unsubscribe(topic);
+        }
     }
 }
 

--- a/src/client/pubsub/mod.rs
+++ b/src/client/pubsub/mod.rs
@@ -1,0 +1,268 @@
+/*
+ * Copyright 2017-2023 Ben Ashford
+ *
+ * Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+ * http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+ * <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+ * option. This file may not be copied, modified, or distributed
+ * except according to those terms.
+ */
+
+mod inner;
+
+use std::future::Future;
+use std::pin::Pin;
+use std::sync::Arc;
+use std::task::{Context, Poll};
+
+use futures_channel::{mpsc, oneshot};
+use futures_util::{
+    future::TryFutureExt,
+    stream::{Stream, StreamExt},
+};
+
+use super::{connect::connect_with_auth, ConnectionBuilder};
+
+use crate::{
+    error,
+    reconnect::{reconnect, Reconnect},
+    resp,
+};
+
+use self::inner::PubsubConnectionInner;
+
+#[derive(Debug)]
+pub(crate) enum PubsubEvent {
+    /// The: topic, sink to send messages through, and a oneshot to signal subscription has
+    /// occurred.
+    Subscribe(String, PubsubSink, oneshot::Sender<()>),
+    Psubscribe(String, PubsubSink, oneshot::Sender<()>),
+    /// The name of the topic to unsubscribe from. Unsubscription will be signaled by the stream
+    /// closing without error.
+    Unsubscribe(String),
+    Punsubscribe(String),
+}
+
+type PubsubStreamInner = mpsc::UnboundedReceiver<Result<resp::RespValue, error::Error>>;
+type PubsubSink = mpsc::UnboundedSender<Result<resp::RespValue, error::Error>>;
+
+/// A shareable reference to subscribe to PUBSUB topics
+#[derive(Debug, Clone)]
+pub struct PubsubConnection {
+    out_tx_c: Arc<Reconnect<PubsubEvent, mpsc::UnboundedSender<PubsubEvent>>>,
+}
+
+async fn inner_conn_fn(
+    // Needs to be a String for lifetime reasons
+    host: String,
+    port: u16,
+    username: Option<Arc<str>>,
+    password: Option<Arc<str>>,
+    tls: bool,
+) -> Result<mpsc::UnboundedSender<PubsubEvent>, error::Error> {
+    let username = username.as_deref();
+    let password = password.as_deref();
+
+    let connection = connect_with_auth(&host, port, username, password, tls).await?;
+    let (out_tx, out_rx) = mpsc::unbounded();
+    tokio::spawn(async {
+        match PubsubConnectionInner::new(connection, out_rx).await {
+            Ok(_) => (),
+            Err(e) => log::error!("Pub/Sub error: {:?}", e),
+        }
+    });
+    Ok(out_tx)
+}
+
+impl ConnectionBuilder {
+    pub fn pubsub_connect(&self) -> impl Future<Output = Result<PubsubConnection, error::Error>> {
+        let username = self.username.clone();
+        let password = self.password.clone();
+
+        #[cfg(feature = "tls")]
+        let tls = self.tls;
+        #[cfg(not(feature = "tls"))]
+        let tls = false;
+
+        let host = self.host.clone();
+        let port = self.port;
+
+        let reconnecting_f = reconnect(
+            |con: &mpsc::UnboundedSender<PubsubEvent>, act| {
+                con.unbounded_send(act).map_err(|e| e.into())
+            },
+            move || {
+                let con_f =
+                    inner_conn_fn(host.clone(), port, username.clone(), password.clone(), tls);
+                Box::pin(con_f)
+            },
+        );
+        reconnecting_f.map_ok(|con| PubsubConnection {
+            out_tx_c: Arc::new(con),
+        })
+    }
+}
+
+/// Used for Redis's PUBSUB functionality.
+///
+/// Returns a future that resolves to a `PubsubConnection`. The future will only resolve once the
+/// connection is established; after the intial establishment, if the connection drops for any
+/// reason (e.g. Redis server being restarted), the connection will attempt re-connect, however
+/// any subscriptions will need to be re-subscribed.
+pub async fn pubsub_connect(
+    host: impl Into<String>,
+    port: u16,
+) -> Result<PubsubConnection, error::Error> {
+    ConnectionBuilder::new(host, port)?.pubsub_connect().await
+}
+
+impl PubsubConnection {
+    /// Subscribes to a particular PUBSUB topic.
+    ///
+    /// Returns a future that resolves to a `Stream` that contains all the messages published on
+    /// that particular topic.
+    ///
+    /// The resolved stream will end with `redis_async::error::Error::EndOfStream` if the
+    /// underlying connection is lost for unexpected reasons. In this situation, clients should
+    /// `subscribe` to re-subscribe; the underlying connect will automatically reconnect. However,
+    /// clients should be aware that resubscriptions will only succeed if the underlying connection
+    /// has re-established, so multiple calls to `subscribe` may be required.
+    pub async fn subscribe(&self, topic: &str) -> Result<PubsubStream, error::Error> {
+        let (tx, rx) = mpsc::unbounded();
+        let (signal_t, signal_r) = oneshot::channel();
+        self.out_tx_c
+            .do_work(PubsubEvent::Subscribe(topic.to_owned(), tx, signal_t))?;
+
+        match signal_r.await {
+            Ok(_) => Ok(PubsubStream {
+                topic: topic.to_owned(),
+                underlying: rx,
+                con: self.clone(),
+            }),
+            Err(_) => Err(error::internal("Subscription failed, try again later...")),
+        }
+    }
+
+    pub async fn psubscribe(&self, topic: &str) -> Result<PubsubStream, error::Error> {
+        let (tx, rx) = mpsc::unbounded();
+        let (signal_t, signal_r) = oneshot::channel();
+        self.out_tx_c
+            .do_work(PubsubEvent::Psubscribe(topic.to_owned(), tx, signal_t))?;
+
+        match signal_r.await {
+            Ok(_) => Ok(PubsubStream {
+                topic: topic.to_owned(),
+                underlying: rx,
+                con: self.clone(),
+            }),
+            Err(_) => Err(error::internal("Subscription failed, try again later...")),
+        }
+    }
+
+    /// Tells the client to unsubscribe from a particular topic. This will return immediately, the
+    /// actual unsubscription will be confirmed when the stream returned from `subscribe` ends.
+    pub fn unsubscribe<T: Into<String>>(&self, topic: T) {
+        // Ignoring any results, as any errors communicating with Redis would de-facto unsubscribe
+        // anyway, and would be reported/logged elsewhere
+        let _ = self
+            .out_tx_c
+            .do_work(PubsubEvent::Unsubscribe(topic.into()));
+    }
+
+    pub fn punsubscribe<T: Into<String>>(&self, topic: T) {
+        // Ignoring any results, as any errors communicating with Redis would de-facto unsubscribe
+        // anyway, and would be reported/logged elsewhere
+        let _ = self
+            .out_tx_c
+            .do_work(PubsubEvent::Punsubscribe(topic.into()));
+    }
+}
+
+#[derive(Debug)]
+pub struct PubsubStream {
+    topic: String,
+    underlying: PubsubStreamInner,
+    con: PubsubConnection,
+}
+
+impl Stream for PubsubStream {
+    type Item = Result<resp::RespValue, error::Error>;
+
+    #[inline]
+    fn poll_next(self: Pin<&mut Self>, cx: &mut Context) -> Poll<Option<Self::Item>> {
+        self.get_mut().underlying.poll_next_unpin(cx)
+    }
+}
+
+impl Drop for PubsubStream {
+    fn drop(&mut self) {
+        let topic: &str = self.topic.as_ref();
+        self.con.unsubscribe(topic);
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use futures::{try_join, StreamExt, TryStreamExt};
+
+    use crate::{client, resp};
+
+    #[tokio::test]
+    async fn subscribe_test() {
+        let paired_c = client::paired_connect("127.0.0.1", 6379);
+        let pubsub_c = super::pubsub_connect("127.0.0.1", 6379);
+        let (paired, pubsub) = try_join!(paired_c, pubsub_c).expect("Cannot connect to Redis");
+
+        let topic_messages = pubsub
+            .subscribe("test-topic")
+            .await
+            .expect("Cannot subscribe to topic");
+
+        paired.send_and_forget(resp_array!["PUBLISH", "test-topic", "test-message"]);
+        paired.send_and_forget(resp_array!["PUBLISH", "test-not-topic", "test-message-1.5"]);
+        let _: resp::RespValue = paired
+            .send(resp_array!["PUBLISH", "test-topic", "test-message2"])
+            .await
+            .expect("Cannot send to topic");
+
+        let result: Vec<_> = topic_messages
+            .take(2)
+            .try_collect()
+            .await
+            .expect("Cannot collect two values");
+
+        assert_eq!(result.len(), 2);
+        assert_eq!(result[0], "test-message".into());
+        assert_eq!(result[1], "test-message2".into());
+    }
+
+    #[tokio::test]
+    async fn psubscribe_test() {
+        let paired_c = client::paired_connect("127.0.0.1", 6379);
+        let pubsub_c = super::pubsub_connect("127.0.0.1", 6379);
+        let (paired, pubsub) = try_join!(paired_c, pubsub_c).expect("Cannot connect to Redis");
+
+        let topic_messages = pubsub
+            .psubscribe("test.*")
+            .await
+            .expect("Cannot subscribe to topic");
+
+        paired.send_and_forget(resp_array!["PUBLISH", "test.1", "test-message-1"]);
+        paired.send_and_forget(resp_array!["PUBLISH", "test.2", "test-message-2"]);
+        let _: resp::RespValue = paired
+            .send(resp_array!["PUBLISH", "test.3", "test-message-3"])
+            .await
+            .expect("Cannot send to topic");
+
+        let result: Vec<_> = topic_messages
+            .take(3)
+            .try_collect()
+            .await
+            .expect("Cannot collect two values");
+
+        assert_eq!(result.len(), 3);
+        assert_eq!(result[0], "test-message-1".into());
+        assert_eq!(result[1], "test-message-2".into());
+        assert_eq!(result[2], "test-message-3".into());
+    }
+}


### PR DESCRIPTION
This should fix both #83 and #84 and some other weird edge-cases.

Specifically it was very easy for a PubSub connection to get into an invalid state, and when in such a state it would fail. This was intended to be a fail-safe design on the principle that it's better to fail than be invalid. However many of those invalid conditions were avoidable in other ways.

So this changes those conditions in a small number of ways:

1. The internal processing of the connection no-longer ends when the last subscription ends. Previously a handle to a `PubsubConnection` could still be held, but not be useable. Now that connection will remain valid for as long as it is held, similar to other connections.

2. Unsubscribing twice is no-longer an error. As Redis itself does not mind, neither should we. This helps when a subscription is specifically terminated, but the catch all unsubscribe-on-drop also kicks in.