### PR TITLE
Better error reporting in the event of a failure

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "redis-async"
-version = "0.15.0"
+version = "0.16.0"
 authors = ["Ben Ashford <benashford@users.noreply.github.com>"]
 license = "MIT/Apache-2.0"
 readme = "README.md"


### PR DESCRIPTION
(in PUBSUB connections)

Previously if there was an internal error with a Pub/Sub connection, it would close the downstream streams. This made it difficult for clients to know what actually went wrong. But in some cases the error would be sent to the client.

This change will mean that all errors are sent to clients, so that they know something has gone wrong.