### PR TITLE
Updated and resilient networking

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -13,32 +13,18 @@ jobs:
           - nightly
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v5
 
-      - uses: actions-rs/toolchain@v1
+      - uses: actions-rust-lang/setup-rust-toolchain@v1
         with:
-          profile: minimal
           toolchain: ${{ matrix.rust }}
-          override: true
           components: rustfmt, clippy
 
-      - uses: supercharge/redis-github-action@1.1.0
+      - uses: supercharge/redis-github-action@1.8.0
         with:
-          redis-version: 6
+          redis-version: 7
 
-      - uses: actions-rs/cargo@v1
-        with:
-          command: build
-
-      - uses: actions-rs/cargo@v1
-        with:
-          command: test
-
-      - uses: actions-rs/cargo@v1
-        with:
-          command: fmt
-          args: --all -- --check
-
-      - uses: actions-rs/cargo@v1
-        with:
-          command: clippy
+      - run: cargo build
+      - run: cargo test
+      - run: cargo clippy -- -D warnings
+      - run: cargo fmt --all -- --check

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,12 +17,12 @@ futures-util = { version = "^0.3.7", features = ["sink"] }
 log = "^0.4.11"
 native-tls = { version = "0.2", optional = true }
 pin-project = "1.0"
-socket2 = { version = "0.5", features = ["all"] }
+socket2 = { version = "0.6.0", features = ["all"] }
 tokio = { version = "1.0", features = ["rt", "net", "time"] }
 tokio-native-tls = { version = "0.3.0", optional = true }
 tokio-rustls = { version = "0.26", optional = true }
 tokio-util = { version = "0.7", features = ["codec"] }
-webpki-roots = { version = "0.26", optional = true }
+webpki-roots = { version = "1.0.2", optional = true }
 
 [features]
 default = []

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "redis-async"
-version = "0.17.2"
+version = "0.18.0"
 authors = ["Ben Ashford <benashford@users.noreply.github.com>"]
 license = "MIT/Apache-2.0"
 readme = "README.md"
@@ -18,7 +18,7 @@ log = "^0.4.11"
 native-tls = { version = "0.2", optional = true }
 pin-project = "1.0"
 socket2 = { version = "0.6.0", features = ["all"] }
-tokio = { version = "1.0", features = ["rt", "net", "time"] }
+tokio = { version = "1.36", features = ["rt", "net", "time"] }
 tokio-native-tls = { version = "0.3.0", optional = true }
 tokio-rustls = { version = "0.26", optional = true }
 tokio-util = { version = "0.7", features = ["codec"] }
@@ -33,4 +33,4 @@ with-native-tls = ["native-tls", "tokio-native-tls", "tls"]
 [dev-dependencies]
 env_logger = "0.11"
 futures = "^0.3.7"
-tokio = { version = "1.0", features = ["full"] }
+tokio = { version = "1.36", features = ["full"] }

--- a/src/client/builder.rs
+++ b/src/client/builder.rs
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020-2024 Ben Ashford
+ * Copyright 2020-2025 Ben Ashford
  *
  * Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
  * http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
@@ -11,7 +11,7 @@
 use std::sync::Arc;
 use std::time::Duration;
 
-use crate::error;
+use crate::{error, reconnect::ReconnectOptions};
 
 #[derive(Debug)]
 /// Connection builder
@@ -20,6 +20,7 @@ pub struct ConnectionBuilder {
     pub(crate) port: u16,
     pub(crate) username: Option<Arc<str>>,
     pub(crate) password: Option<Arc<str>>,
+    pub(crate) reconnect_options: ReconnectOptions,
     #[cfg(feature = "tls")]
     pub(crate) tls: bool,
     pub(crate) socket_keepalive: Option<Duration>,
@@ -36,6 +37,7 @@ impl ConnectionBuilder {
             port,
             username: None,
             password: None,
+            reconnect_options: ReconnectOptions::default(),
             #[cfg(feature = "tls")]
             tls: false,
             socket_keepalive: Some(DEFAULT_KEEPALIVE),
@@ -70,6 +72,18 @@ impl ConnectionBuilder {
     /// Set the socket timeout duration
     pub fn socket_timeout(&mut self, duration: Option<Duration>) -> &mut Self {
         self.socket_timeout = duration;
+        self
+    }
+
+    /// Set the reconnect timeout
+    pub fn reconnect_timeout(&mut self, duration: Duration) -> &mut Self {
+        self.reconnect_options.connection_timeout = duration;
+        self
+    }
+
+    /// Set the number of reconnection attempts
+    pub fn reconnect_attempts(&mut self, attempts: u64) -> &mut Self {
+        self.reconnect_options.max_connection_attempts = attempts;
         self
     }
 }

--- a/src/client/connect.rs
+++ b/src/client/connect.rs
@@ -24,7 +24,13 @@ use crate::{
 };
 
 #[pin_project(project = RespConnectionInnerProj)]
-#[expect(clippy::large_enum_variant, reason = "will only be enabled if selected, and isn't moved once built")]
+#[cfg_attr(
+    any(feature = "with-rustls", feature = "with-native-tls"),
+    expect(
+        clippy::large_enum_variant,
+        reason = "will only be enabled if selected, and isn't moved once built"
+    )
+)]
 pub enum RespConnectionInner {
     #[cfg(feature = "with-rustls")]
     Tls {

--- a/src/client/connect.rs
+++ b/src/client/connect.rs
@@ -24,6 +24,7 @@ use crate::{
 };
 
 #[pin_project(project = RespConnectionInnerProj)]
+#[expect(clippy::large_enum_variant, reason = "will only be enabled if selected, and isn't moved once built")]
 pub enum RespConnectionInner {
     #[cfg(feature = "with-rustls")]
     Tls {

--- a/src/client/mod.rs
+++ b/src/client/mod.rs
@@ -13,11 +13,11 @@
 //! This contains three main functions that return three specific types of client:
 //!
 //! * `connect` returns a pair of `Stream` and `Sink`, clients can write RESP messages to the
-//! `Sink` and read RESP messages from the `Stream`. Pairing requests to responses is up to the
-//! client.  This is intended to be a low-level interface from which more user-friendly interfaces
-//! can be built.
+//!   `Sink` and read RESP messages from the `Stream`. Pairing requests to responses is up to the
+//!   client.  This is intended to be a low-level interface from which more user-friendly interfaces
+//!   can be built.
 //! * `paired_connect` is used for most of the standard Redis commands, where one request results
-//! in one response.
+//!   in one response.
 //! * `pubsub_connect` is used for Redis's PUBSUB functionality.
 
 pub mod connect;

--- a/src/client/paired.rs
+++ b/src/client/paired.rs
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2024 Ben Ashford
+ * Copyright 2017-2025 Ben Ashford
  *
  * Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
  * http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
@@ -264,7 +264,7 @@ impl ConnectionBuilder {
             Box::pin(con_f) as Pin<Box<dyn Future<Output = Result<_, error::Error>> + Send + Sync>>
         };
 
-        let reconnecting_con = reconnect(work_fn, conn_fn);
+        let reconnecting_con = reconnect(work_fn, conn_fn, self.reconnect_options);
         reconnecting_con.map_ok(|con| PairedConnection {
             out_tx_c: Arc::new(con),
         })

--- a/src/client/pubsub/mod.rs
+++ b/src/client/pubsub/mod.rs
@@ -551,6 +551,9 @@ mod test {
             "test-message-1.5"
         ]);
 
+        // Allow for the messages to be sent
+        sleep(Duration::from_millis(1000)).await;
+
         pubsub.unsubscribe(UNSUBSCRIBE_TWICE_TOPIC_1);
 
         let result1 = topic_1

--- a/src/client/pubsub/mod.rs
+++ b/src/client/pubsub/mod.rs
@@ -234,8 +234,10 @@ impl Drop for PubsubStream {
 #[cfg(test)]
 mod test {
     use std::mem;
+    use std::time::Duration;
 
     use futures::{try_join, StreamExt, TryStreamExt};
+    use tokio::time::sleep;
 
     use crate::{client, resp};
 
@@ -357,6 +359,9 @@ mod test {
         // Unsubscribe from topic 2
         pubsub.unsubscribe(UNSUBSCRIBE_TOPIC_2);
 
+        // Ensure unsubscription is processed
+        sleep(Duration::from_millis(1000)).await;
+
         // Drop the subscription for topic 3
         mem::drop(topic_3);
 
@@ -414,6 +419,9 @@ mod test {
         // Unsubscribe from topic 1
         pubsub.unsubscribe(RESUBSCRIBE_TOPIC);
 
+        // Yes, I know, just testing...
+        sleep(Duration::from_millis(1000)).await;
+
         // Send some more messages
         paired.send_and_forget(resp_array![
             "PUBLISH",
@@ -423,7 +431,6 @@ mod test {
 
         // Get the next message for topic 1
         let result1 = topic_1.next().await;
-        println!("{:?}", result1);
         assert!(result1.is_none());
 
         // Resubscribe to topic 1

--- a/src/client/pubsub/mod.rs
+++ b/src/client/pubsub/mod.rs
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2024 Ben Ashford
+ * Copyright 2017-2025 Ben Ashford
  *
  * Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
  * http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
@@ -118,6 +118,7 @@ impl ConnectionBuilder {
                 );
                 Box::pin(con_f)
             },
+            self.reconnect_options,
         );
         reconnecting_f.map_ok(|con| PubsubConnection {
             out_tx_c: Arc::new(con),

--- a/src/client/pubsub/mod.rs
+++ b/src/client/pubsub/mod.rs
@@ -423,6 +423,7 @@ mod test {
 
         // Get the next message for topic 1
         let result1 = topic_1.next().await;
+        println!("{:?}", result1);
         assert!(result1.is_none());
 
         // Resubscribe to topic 1

--- a/src/reconnect.rs
+++ b/src/reconnect.rs
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018-2020 Ben Ashford
+ * Copyright 2018-2025 Ben Ashford
  *
  * Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
  * http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
@@ -28,10 +28,31 @@ type WorkFn<T, A> = dyn Fn(&T, A) -> Result<(), error::Error> + Send + Sync;
 type ConnFn<T> =
     dyn Fn() -> Pin<Box<dyn Future<Output = Result<T, error::Error>> + Send + Sync>> + Send + Sync;
 
+const CONNECTION_TIMEOUT_SECONDS: u64 = 1;
+const MAX_CONNECTION_ATTEMPTS: u64 = 10;
+const CONNECTION_TIMEOUT: Duration = Duration::from_secs(CONNECTION_TIMEOUT_SECONDS);
+
+#[derive(Debug, Copy, Clone)]
+pub(crate) struct ReconnectOptions {
+    pub(crate) connection_timeout: Duration,
+    pub(crate) max_connection_attempts: u64,
+}
+
+impl Default for ReconnectOptions {
+    #[inline]
+    fn default() -> Self {
+        ReconnectOptions {
+            connection_timeout: CONNECTION_TIMEOUT,
+            max_connection_attempts: MAX_CONNECTION_ATTEMPTS,
+        }
+    }
+}
+
 struct ReconnectInner<A, T> {
     state: Mutex<ReconnectState<T>>,
     work_fn: Box<WorkFn<T, A>>,
     conn_fn: Box<ConnFn<T>>,
+    reconnect_options: ReconnectOptions,
 }
 
 impl<A, T> fmt::Debug for ReconnectInner<A, T> {
@@ -62,7 +83,11 @@ impl<A, T> Clone for Reconnect<A, T> {
     }
 }
 
-pub(crate) async fn reconnect<A, T, W, C>(w: W, c: C) -> Result<Reconnect<A, T>, error::Error>
+pub(crate) async fn reconnect<A, T, W, C>(
+    w: W,
+    c: C,
+    options: ReconnectOptions,
+) -> Result<Reconnect<A, T>, error::Error>
 where
     A: Send + 'static,
     W: Fn(&T, A) -> Result<(), error::Error> + Send + Sync + 'static,
@@ -77,6 +102,8 @@ where
 
         work_fn: Box::new(w),
         conn_fn: Box::new(c),
+
+        reconnect_options: options,
     }));
     let rf = {
         let state = r.0.state.lock().expect("Poisoned lock");
@@ -97,18 +124,13 @@ impl<T> fmt::Debug for ReconnectState<T> {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "ReconnectState::")?;
         match self {
-            NotConnected => write!(f, "NotConnected"),
-            Connected(_) => write!(f, "Connected"),
-            ConnectionFailed(_) => write!(f, "ConnectionFailed"),
-            Connecting => write!(f, "Connecting"),
+            Self::NotConnected => write!(f, "NotConnected"),
+            Self::Connected(_) => write!(f, "Connected"),
+            Self::ConnectionFailed(_) => write!(f, "ConnectionFailed"),
+            Self::Connecting => write!(f, "Connecting"),
         }
     }
 }
-
-use self::ReconnectState::*;
-
-const CONNECTION_TIMEOUT_SECONDS: u64 = 10;
-const CONNECTION_TIMEOUT: Duration = Duration::from_secs(CONNECTION_TIMEOUT_SECONDS);
 
 impl<A, T> Reconnect<A, T>
 where
@@ -133,19 +155,19 @@ where
     pub(crate) fn do_work(&self, a: A) -> Result<(), error::Error> {
         let mut state = self.0.state.lock().expect("Cannot obtain read lock");
         match *state {
-            NotConnected => {
+            ReconnectState::NotConnected => {
                 self.reconnect_spawn(state);
                 Err(error::Error::Connection(ConnectionReason::NotConnected))
             }
-            Connected(ref t) => {
+            ReconnectState::Connected(ref t) => {
                 let success = self.call_work(t, a)?;
                 if !success {
-                    *state = NotConnected;
+                    *state = ReconnectState::NotConnected;
                     self.reconnect_spawn(state);
                 }
                 Ok(())
             }
-            ConnectionFailed(ref e) => {
+            ReconnectState::ConnectionFailed(ref e) => {
                 let mut lock = e.lock().expect("Poisioned lock");
                 let e = match lock.take() {
                     Some(e) => e,
@@ -153,11 +175,13 @@ where
                 };
                 mem::drop(lock);
 
-                *state = NotConnected;
+                *state = ReconnectState::NotConnected;
                 self.reconnect_spawn(state);
                 Err(e)
             }
-            Connecting => Err(error::Error::Connection(ConnectionReason::Connecting)),
+            ReconnectState::Connecting => {
+                Err(error::Error::Connection(ConnectionReason::Connecting))
+            }
         }
     }
 
@@ -170,17 +194,17 @@ where
         log::info!("Attempting to reconnect, current state: {:?}", *state);
 
         match *state {
-            Connected(_) => {
+            ReconnectState::Connected(_) => {
                 return Either::Right(future::err(error::Error::Connection(
                     ConnectionReason::Connected,
                 )));
             }
-            Connecting => {
+            ReconnectState::Connecting => {
                 return Either::Right(future::err(error::Error::Connection(
                     ConnectionReason::Connecting,
                 )));
             }
-            NotConnected | ConnectionFailed(_) => (),
+            ReconnectState::NotConnected | ReconnectState::ConnectionFailed(_) => (),
         }
         *state = ReconnectState::Connecting;
 
@@ -189,33 +213,54 @@ where
         let reconnect = self.clone();
 
         let connection_f = async move {
-            let connection = match timeout(CONNECTION_TIMEOUT, (reconnect.0.conn_fn)()).await {
-                Ok(con_r) => con_r,
-                Err(_) => Err(error::internal(format!(
-                    "Connection timed-out after {} seconds",
-                    CONNECTION_TIMEOUT_SECONDS
-                ))),
-            };
+            let mut connection_result = Err(error::internal("Initial connection failed"));
+            for i in 0..reconnect.0.reconnect_options.max_connection_attempts {
+                log::debug!(
+                    "Connection attempt {}/{}",
+                    i + 1,
+                    reconnect.0.reconnect_options.max_connection_attempts
+                );
+                connection_result = match timeout(
+                    reconnect.0.reconnect_options.connection_timeout,
+                    (reconnect.0.conn_fn)(),
+                )
+                .await
+                {
+                    Ok(con_r) => con_r,
+                    Err(_) => Err(error::internal(format!(
+                        "Connection timed-out after {} seconds",
+                        reconnect.0.reconnect_options.connection_timeout.as_secs()
+                            * reconnect.0.reconnect_options.max_connection_attempts
+                    ))),
+                };
+                if connection_result.is_ok() {
+                    break;
+                }
+            }
 
             let mut state = reconnect.0.state.lock().expect("Cannot obtain write lock");
 
             match *state {
-                NotConnected | Connecting => match connection {
-                    Ok(t) => {
-                        log::info!("Connection established");
-                        *state = Connected(t);
-                        Ok(())
+                ReconnectState::NotConnected | ReconnectState::Connecting => {
+                    match connection_result {
+                        Ok(t) => {
+                            log::info!("Connection established");
+                            *state = ReconnectState::Connected(t);
+                            Ok(())
+                        }
+                        Err(e) => {
+                            log::error!("Connection cannot be established: {}", e);
+                            *state = ReconnectState::ConnectionFailed(Mutex::new(Some(e)));
+                            Err(error::Error::Connection(ConnectionReason::ConnectionFailed))
+                        }
                     }
-                    Err(e) => {
-                        log::error!("Connection cannot be established: {}", e);
-                        *state = ConnectionFailed(Mutex::new(Some(e)));
-                        Err(error::Error::Connection(ConnectionReason::ConnectionFailed))
-                    }
-                },
-                ConnectionFailed(_) => {
+                }
+                ReconnectState::ConnectionFailed(_) => {
                     panic!("The connection state wasn't reset before connecting")
                 }
-                Connected(_) => panic!("A connected state shouldn't be attempting to reconnect"),
+                ReconnectState::Connected(_) => {
+                    panic!("A connected state shouldn't be attempting to reconnect")
+                }
             }
         };
 

--- a/src/reconnect.rs
+++ b/src/reconnect.rs
@@ -215,9 +215,10 @@ where
         let connection_f = async move {
             let mut connection_result = Err(error::internal("Initial connection failed"));
             for i in 0..reconnect.0.reconnect_options.max_connection_attempts {
+                let connection_count = i + 1;
                 log::debug!(
                     "Connection attempt {}/{}",
-                    i + 1,
+                    connection_count,
                     reconnect.0.reconnect_options.max_connection_attempts
                 );
                 connection_result = match timeout(
@@ -230,7 +231,7 @@ where
                     Err(_) => Err(error::internal(format!(
                         "Connection timed-out after {} seconds",
                         reconnect.0.reconnect_options.connection_timeout.as_secs()
-                            * reconnect.0.reconnect_options.max_connection_attempts
+                            * connection_count
                     ))),
                 };
                 if connection_result.is_ok() {

--- a/src/resp.rs
+++ b/src/resp.rs
@@ -182,9 +182,9 @@ macro_rules! impl_fromresp_integers {
                     i64::from_resp_int(resp).and_then(|x| {
                         // $int_ty::max_value() as i64 > 0 should be optimized out. It tests if
                         // the target integer type needs an "upper bounds" check
-                        if x < ($int_ty::min_value() as i64)
-                            || ($int_ty::max_value() as i64 > 0
-                                && x > ($int_ty::max_value() as i64))
+                        if x < ($int_ty::MIN as i64)
+                            || ($int_ty::MAX as i64 > 0
+                                && x > ($int_ty::MAX as i64))
                         {
                             Err(error::resp(
                                 concat!(
@@ -424,7 +424,7 @@ impl IntoRespString for String {
 }
 string_into_resp!(String);
 
-impl<'a> IntoRespString for &'a String {
+impl IntoRespString for &String {
     #[inline]
     fn into_resp_string(self) -> RespValue {
         RespValue::BulkString(self.as_bytes().into())
@@ -432,7 +432,7 @@ impl<'a> IntoRespString for &'a String {
 }
 string_into_resp!(&'a String);
 
-impl<'a> IntoRespString for &'a str {
+impl IntoRespString for &str {
     #[inline]
     fn into_resp_string(self) -> RespValue {
         RespValue::BulkString(self.as_bytes().into())
@@ -440,7 +440,7 @@ impl<'a> IntoRespString for &'a str {
 }
 string_into_resp!(&'a str);
 
-impl<'a> IntoRespString for &'a [u8] {
+impl IntoRespString for &[u8] {
     #[inline]
     fn into_resp_string(self) -> RespValue {
         RespValue::BulkString(self.to_vec())
@@ -814,7 +814,7 @@ mod tests {
 
     #[test]
     fn test_integer_overflow() {
-        let resp_object = RespValue::Integer(i64::max_value());
+        let resp_object = RespValue::Integer(i64::MAX);
         let res = i32::from_resp(resp_object);
         assert!(res.is_err());
     }


### PR DESCRIPTION
Minor modification to the way connections happen.

Now will retry more than once, before marking the connection as failed, with a smaller timeout. This is now also customisable. It will stay in a Connecting state while this happens.

This is to aide resilience in unreliable environments, e.g. Kubernetes clusters and other such situations.