### PR TITLE
Refactor FromResp trait to standard TryFrom

### DIFF
--- a/examples/psubscribe.rs
+++ b/examples/psubscribe.rs
@@ -12,7 +12,7 @@ use std::env;
 
 use futures::StreamExt;
 
-use redis_async::{client, resp::FromResp};
+use redis_async::client;
 
 #[tokio::main]
 async fn main() {
@@ -32,7 +32,7 @@ async fn main() {
 
     while let Some(message) = msgs.next().await {
         match message {
-            Ok(message) => println!("{}", String::from_resp(message).unwrap()),
+            Ok(message) => println!("{}", String::try_from(message).unwrap()),
             Err(e) => {
                 eprintln!("ERROR: {}", e);
                 break;

--- a/examples/subscribe.rs
+++ b/examples/subscribe.rs
@@ -12,7 +12,7 @@ use std::env;
 
 use futures::StreamExt;
 
-use redis_async::{client, resp::FromResp};
+use redis_async::client;
 
 #[tokio::main]
 async fn main() {
@@ -34,7 +34,7 @@ async fn main() {
 
     while let Some(message) = msgs.next().await {
         match message {
-            Ok(message) => println!("{}", String::from_resp(message).unwrap()),
+            Ok(message) => println!("{}", String::try_from(message).unwrap()),
             Err(e) => {
                 eprintln!("ERROR: {}", e);
                 break;

--- a/src/client/connect.rs
+++ b/src/client/connect.rs
@@ -18,10 +18,7 @@ use tokio::{
 };
 use tokio_util::codec::{Decoder, Framed};
 
-use crate::{
-    error,
-    resp::RespCodec,
-};
+use crate::{error, resp::RespCodec};
 
 #[pin_project(project = RespConnectionInnerProj)]
 #[cfg_attr(

--- a/src/client/connect.rs
+++ b/src/client/connect.rs
@@ -20,7 +20,7 @@ use tokio_util::codec::{Decoder, Framed};
 
 use crate::{
     error,
-    resp::{self, RespCodec},
+    resp::RespCodec,
 };
 
 #[pin_project(project = RespConnectionInnerProj)]
@@ -223,7 +223,7 @@ pub async fn connect_with_auth(
 
         connection.send(auth).await?;
         match connection.next().await {
-            Some(Ok(value)) => match resp::FromResp::from_resp(value) {
+            Some(Ok(value)) => match <()>::try_from(value) {
                 Ok(()) => (),
                 Err(e) => return Err(e),
             },

--- a/src/client/paired.rs
+++ b/src/client/paired.rs
@@ -294,7 +294,8 @@ impl PairedConnection {
     ///
     /// The message must be in the format of a single RESP message, this can be constructed
     /// manually or with the `resp_array!` macro.  Returned is a future that resolves to the value
-    /// returned from Redis.  The type must be one for which the `resp::FromResp` trait is defined.
+    /// Returned is a future that resolves to the value returned from Redis.  The type must be one
+    /// for which the `TryFrom<resp::RespValue>` trait is defined where `error::Error: From<T::Error>`.
     ///
     /// The future will fail for numerous reasons, including but not limited to: IO issues, conversion
     /// problems, and server-side errors being returned by Redis.
@@ -304,7 +305,8 @@ impl PairedConnection {
     /// that `send` is called.
     pub fn send<T>(&self, msg: resp::RespValue) -> SendFuture<T>
     where
-        T: resp::FromResp + Unpin,
+        T: TryFrom<resp::RespValue> + Unpin,
+        error::Error: From<T::Error>,
     {
         match &msg {
             resp::RespValue::Array(_) => (),
@@ -368,7 +370,8 @@ impl<T> SendFuture<T> {
 
 impl<T> Future for SendFuture<T>
 where
-    T: resp::FromResp + Unpin,
+    T: TryFrom<resp::RespValue> + Unpin,
+    error::Error: From<T::Error>,
 {
     type Output = Result<T, error::Error>;
 
@@ -380,7 +383,10 @@ where
                 None => panic!("Future polled several times after completion"),
             },
             SendFutureType::Wait(ref mut rx) => match Pin::new(rx).poll(cx) {
-                Poll::Ready(Ok(Ok(v))) => Poll::Ready(T::from_resp(v)),
+                Poll::Ready(Ok(Ok(v))) => match v.into_result() {
+                    Ok(v) => Poll::Ready(T::try_from(v).map_err(error::Error::from)),
+                    Err(e) => Poll::Ready(Err(e)),
+                },
                 Poll::Ready(Ok(Err(e))) => Poll::Ready(Err(e)),
                 Poll::Ready(Err(_)) => Poll::Ready(Err(error::internal(
                     "Connection closed before response received",

--- a/src/client/pubsub/inner.rs
+++ b/src/client/pubsub/inner.rs
@@ -21,7 +21,7 @@ use futures_util::stream::{Fuse, StreamExt};
 use crate::{
     client::connect::RespConnection,
     error::{self, ConnectionReason},
-    resp::{self, FromResp},
+    resp,
 };
 
 use super::{PubsubEvent, PubsubSink};
@@ -132,13 +132,13 @@ impl PubsubConnectionInner {
                 messages.pop(),
             ) {
                 (Some(msg), Some(topic), Some(message_type), None) => {
-                    match (msg, String::from_resp(topic), message_type) {
+                    match (msg, String::try_from(topic), message_type) {
                         (msg, Ok(topic), resp::RespValue::BulkString(bytes)) => (bytes, topic, msg),
                         _ => return Err(error::unexpected("Incorrect format of a PUBSUB message")),
                     }
                 }
                 (Some(msg), Some(_), Some(topic), Some(message_type)) => {
-                    match (msg, String::from_resp(topic), message_type) {
+                    match (msg, String::try_from(topic), message_type) {
                         (msg, Ok(topic), resp::RespValue::BulkString(bytes)) => (bytes, topic, msg),
                         _ => return Err(error::unexpected("Incorrect format of a PUBSUB message")),
                     }

--- a/src/client/pubsub/mod.rs
+++ b/src/client/pubsub/mod.rs
@@ -421,11 +421,14 @@ mod test {
         assert!(result1.is_none());
 
         // Send some more messages (will be ignored since we are unsubscribed)
-        paired.send_and_forget(resp_array![
-            "PUBLISH",
-            RESUBSCRIBE_TOPIC,
-            "test-message-1.5"
-        ]);
+        let _: usize = paired
+            .send(resp_array![
+                "PUBLISH",
+                RESUBSCRIBE_TOPIC,
+                "test-message-1.5"
+            ])
+            .await
+            .expect("Cannot publish");
 
         // Resubscribe to topic 1
         let mut topic_1 = pubsub

--- a/src/client/pubsub/mod.rs
+++ b/src/client/pubsub/mod.rs
@@ -359,8 +359,9 @@ mod test {
         // Unsubscribe from topic 2
         pubsub.unsubscribe(UNSUBSCRIBE_TOPIC_2);
 
-        // Ensure unsubscription is processed
-        sleep(Duration::from_millis(1000)).await;
+        // Get the next message for topic 2 - confirms unsubscription has been processed by Redis
+        let result2 = topic_2.next().await;
+        assert!(result2.is_none());
 
         // Drop the subscription for topic 3
         mem::drop(topic_3);
@@ -389,10 +390,6 @@ mod test {
             .expect("Cannot get next value")
             .expect("Cannot get next value");
         assert_eq!(result1, "test-message-1.5".into());
-
-        // Get the next message for topic 2
-        let result2 = topic_2.next().await;
-        assert!(result2.is_none());
     }
 
     /// Test that we can subscribe, unsubscribe, and resubscribe to a topic.
@@ -419,19 +416,16 @@ mod test {
         // Unsubscribe from topic 1
         pubsub.unsubscribe(RESUBSCRIBE_TOPIC);
 
-        // Yes, I know, just testing...
-        sleep(Duration::from_millis(1000)).await;
+        // Get the next message for topic 1 - confirms unsubscription has been processed by Redis
+        let result1 = topic_1.next().await;
+        assert!(result1.is_none());
 
-        // Send some more messages
+        // Send some more messages (will be ignored since we are unsubscribed)
         paired.send_and_forget(resp_array![
             "PUBLISH",
             RESUBSCRIBE_TOPIC,
             "test-message-1.5"
         ]);
-
-        // Get the next message for topic 1
-        let result1 = topic_1.next().await;
-        assert!(result1.is_none());
 
         // Resubscribe to topic 1
         let mut topic_1 = pubsub

--- a/src/error.rs
+++ b/src/error.rs
@@ -70,6 +70,12 @@ impl From<io::Error> for Error {
     }
 }
 
+impl From<std::convert::Infallible> for Error {
+    fn from(err: std::convert::Infallible) -> Error {
+        match err {}
+    }
+}
+
 impl<T: 'static + Send> From<mpsc::TrySendError<T>> for Error {
     fn from(err: mpsc::TrySendError<T>) -> Error {
         Error::Unexpected(format!("Cannot write to channel: {}", err))

--- a/src/resp.rs
+++ b/src/resp.rs
@@ -50,7 +50,7 @@ pub enum RespValue {
 
 impl RespValue {
     #[inline]
-    fn into_result(self) -> Result<RespValue, Error> {
+    pub(crate) fn into_result(self) -> Result<RespValue, Error> {
         match self {
             RespValue::Error(string) => Err(Error::Remote(string)),
             x => Ok(x),
@@ -108,78 +108,68 @@ impl fmt::Debug for RespValue {
     }
 }
 
-/// A trait to be implemented for every time which can be read from a RESP value.
-///
-/// Implementing this trait on a type means that type becomes a valid return type for calls such as `send` on
-/// `client::PairedConnection`
-pub trait FromResp: Sized {
-    /// Return a `Result` containing either `Self` or `Error`.  Errors can occur due to either: a) the particular
-    /// `RespValue` being incompatible with the required type, or b) a remote Redis error occuring.
-    #[inline]
-    fn from_resp(resp: RespValue) -> Result<Self, Error> {
-        Self::from_resp_int(resp.into_result()?)
-    }
 
-    fn from_resp_int(resp: RespValue) -> Result<Self, Error>;
-}
 
-impl FromResp for RespValue {
-    #[inline]
-    fn from_resp_int(resp: RespValue) -> Result<RespValue, Error> {
-        Ok(resp)
-    }
-}
+impl TryFrom<RespValue> for String {
+    type Error = Error;
 
-impl FromResp for String {
     #[inline]
-    fn from_resp_int(resp: RespValue) -> Result<String, Error> {
-        match resp {
+    fn try_from(resp: RespValue) -> Result<String, Error> {
+        match resp.into_result()? {
             RespValue::BulkString(ref bytes) => Ok(String::from_utf8_lossy(bytes).into_owned()),
             RespValue::Integer(i) => Ok(i.to_string()),
             RespValue::SimpleString(string) => Ok(string),
-            _ => Err(error::resp("Cannot convert into a string", resp)),
+            other => Err(error::resp("Cannot convert into a string", other)),
         }
     }
 }
 
-impl FromResp for Arc<str> {
+impl TryFrom<RespValue> for Arc<str> {
+    type Error = Error;
+
     #[inline]
-    fn from_resp_int(resp: RespValue) -> Result<Arc<str>, Error> {
-        match resp {
+    fn try_from(resp: RespValue) -> Result<Arc<str>, Error> {
+        match resp.into_result()? {
             RespValue::BulkString(ref bytes) => Ok(String::from_utf8_lossy(bytes).into()),
-            _ => Err(error::resp("Cannot convert into a Arc<str>", resp)),
+            other => Err(error::resp("Cannot convert into a Arc<str>", other)),
         }
     }
 }
 
-impl FromResp for Vec<u8> {
+impl TryFrom<RespValue> for Vec<u8> {
+    type Error = Error;
+
     #[inline]
-    fn from_resp_int(resp: RespValue) -> Result<Vec<u8>, Error> {
-        match resp {
+    fn try_from(resp: RespValue) -> Result<Vec<u8>, Error> {
+        match resp.into_result()? {
             RespValue::BulkString(bytes) => Ok(bytes),
-            _ => Err(error::resp("Not a bulk string", resp)),
+            other => Err(error::resp("Not a bulk string", other)),
         }
     }
 }
 
-impl FromResp for i64 {
+impl TryFrom<RespValue> for i64 {
+    type Error = Error;
+
     #[inline]
-    fn from_resp_int(resp: RespValue) -> Result<i64, Error> {
-        match resp {
+    fn try_from(resp: RespValue) -> Result<i64, Error> {
+        match resp.into_result()? {
             RespValue::Integer(i) => Ok(i),
-            _ => Err(error::resp("Cannot be converted into an i64", resp)),
+            other => Err(error::resp("Cannot be converted into an i64", other)),
         }
     }
 }
 
-macro_rules! impl_fromresp_integers {
+macro_rules! impl_tryfrom_integers {
     ($($int_ty:ident),* $(,)*) => {
         $(
             #[allow(clippy::cast_lossless)]
-            impl FromResp for $int_ty {
+            impl TryFrom<RespValue> for $int_ty {
+                type Error = Error;
+
                 #[inline]
-                fn from_resp_int(resp: RespValue) -> Result<Self, Error> {
-                    i64::from_resp_int(resp).and_then(|x| {
+                fn try_from(resp: RespValue) -> Result<Self, Self::Error> {
+                    i64::try_from(resp).and_then(|x| {
                         // $int_ty::max_value() as i64 > 0 should be optimized out. It tests if
                         // the target integer type needs an "upper bounds" check
                         if x < ($int_ty::MIN as i64)
@@ -203,12 +193,14 @@ macro_rules! impl_fromresp_integers {
     };
 }
 
-impl_fromresp_integers!(isize, usize, i32, u32, u64);
+impl_tryfrom_integers!(isize, usize, i32, u32, u64);
 
-impl FromResp for bool {
+impl TryFrom<RespValue> for bool {
+    type Error = Error;
+
     #[inline]
-    fn from_resp_int(resp: RespValue) -> Result<bool, Error> {
-        i64::from_resp_int(resp).and_then(|x| match x {
+    fn try_from(resp: RespValue) -> Result<bool, Error> {
+        i64::try_from(resp).and_then(|x| match x {
             0 => Ok(false),
             1 => Ok(true),
             _ => Err(error::resp(
@@ -219,42 +211,49 @@ impl FromResp for bool {
     }
 }
 
-impl<T: FromResp> FromResp for Option<T> {
+impl<T: TryFrom<RespValue, Error = Error>> TryFrom<RespValue> for Option<T> {
+    type Error = Error;
+
     #[inline]
-    fn from_resp_int(resp: RespValue) -> Result<Option<T>, Error> {
-        match resp {
+    fn try_from(resp: RespValue) -> Result<Option<T>, Error> {
+        match resp.into_result()? {
             RespValue::Nil => Ok(None),
-            x => Ok(Some(T::from_resp_int(x)?)),
+            other => Ok(Some(T::try_from(other)?)),
         }
     }
 }
 
-impl<T: FromResp> FromResp for Vec<T> {
+impl<T: TryFrom<RespValue, Error = Error>> TryFrom<RespValue> for Vec<T> {
+    type Error = Error;
+
     #[inline]
-    fn from_resp_int(resp: RespValue) -> Result<Vec<T>, Error> {
-        match resp {
+    fn try_from(resp: RespValue) -> Result<Vec<T>, Error> {
+        match resp.into_result()? {
             RespValue::Array(ary) => {
                 let mut ar = Vec::with_capacity(ary.len());
                 for value in ary {
-                    ar.push(T::from_resp(value)?);
+                    ar.push(T::try_from(value)?);
                 }
                 Ok(ar)
             }
-            _ => Err(error::resp("Cannot be converted into a vector", resp)),
+            other => Err(error::resp("Cannot be converted into a vector", other)),
         }
     }
 }
 
-impl<K: FromResp + Hash + Eq, T: FromResp, S: BuildHasher + Default> FromResp for HashMap<K, T, S> {
-    fn from_resp_int(resp: RespValue) -> Result<HashMap<K, T, S>, Error> {
-        match resp {
+impl<K: TryFrom<RespValue, Error = Error> + Hash + Eq, T: TryFrom<RespValue, Error = Error>, S: BuildHasher + Default> TryFrom<RespValue> for HashMap<K, T, S> {
+    type Error = Error;
+
+    #[inline]
+    fn try_from(resp: RespValue) -> Result<HashMap<K, T, S>, Error> {
+        match resp.into_result()? {
             RespValue::Array(ary) => {
                 let mut map = HashMap::with_capacity_and_hasher(ary.len(), S::default());
                 let mut items = ary.into_iter();
 
                 while let Some(k) = items.next() {
-                    let key = K::from_resp(k)?;
-                    let value = T::from_resp(items.next().ok_or_else(|| {
+                    let key = K::try_from(k)?;
+                    let value = T::try_from(items.next().ok_or_else(|| {
                         error::resp(
                             "Cannot convert an odd number of elements into a hashmap",
                             "".into(),
@@ -266,15 +265,17 @@ impl<K: FromResp + Hash + Eq, T: FromResp, S: BuildHasher + Default> FromResp fo
 
                 Ok(map)
             }
-            _ => Err(error::resp("Cannot be converted into a hashmap", resp)),
+            other => Err(error::resp("Cannot be converted into a hashmap", other)),
         }
     }
 }
 
-impl FromResp for () {
+impl TryFrom<RespValue> for () {
+    type Error = Error;
+
     #[inline]
-    fn from_resp_int(resp: RespValue) -> Result<(), Error> {
-        match resp {
+    fn try_from(resp: RespValue) -> Result<(), Error> {
+        match resp.into_result()? {
             RespValue::SimpleString(string) => match string.as_ref() {
                 "OK" => Ok(()),
                 _ => Err(Error::Resp(
@@ -282,28 +283,30 @@ impl FromResp for () {
                     None,
                 )),
             },
-            _ => Err(error::resp(
+            other => Err(error::resp(
                 "Unexpected value, should be encoded as a SimpleString",
-                resp,
+                other,
             )),
         }
     }
 }
 
-impl<A, B> FromResp for (A, B)
+impl<A, B> TryFrom<RespValue> for (A, B)
 where
-    A: FromResp,
-    B: FromResp,
+    A: TryFrom<RespValue, Error = Error>,
+    B: TryFrom<RespValue, Error = Error>,
 {
+    type Error = Error;
+
     #[inline]
-    fn from_resp_int(resp: RespValue) -> Result<(A, B), Error> {
-        match resp {
+    fn try_from(resp: RespValue) -> Result<(A, B), Error> {
+        match resp.into_result()? {
             RespValue::Array(ary) => {
                 if ary.len() == 2 {
                     let mut ary_iter = ary.into_iter();
                     Ok((
-                        A::from_resp(ary_iter.next().expect("No value"))?,
-                        B::from_resp(ary_iter.next().expect("No value"))?,
+                        A::try_from(ary_iter.next().expect("No value"))?,
+                        B::try_from(ary_iter.next().expect("No value"))?,
                     ))
                 } else {
                     Err(Error::Resp(
@@ -312,30 +315,32 @@ where
                     ))
                 }
             }
-            _ => Err(error::resp(
+            other => Err(error::resp(
                 "Unexpected value, should be encoded as an array",
-                resp,
+                other,
             )),
         }
     }
 }
 
-impl<A, B, C> FromResp for (A, B, C)
+impl<A, B, C> TryFrom<RespValue> for (A, B, C)
 where
-    A: FromResp,
-    B: FromResp,
-    C: FromResp,
+    A: TryFrom<RespValue, Error = Error>,
+    B: TryFrom<RespValue, Error = Error>,
+    C: TryFrom<RespValue, Error = Error>,
 {
+    type Error = Error;
+
     #[inline]
-    fn from_resp_int(resp: RespValue) -> Result<(A, B, C), Error> {
-        match resp {
+    fn try_from(resp: RespValue) -> Result<(A, B, C), Error> {
+        match resp.into_result()? {
             RespValue::Array(ary) => {
                 if ary.len() == 3 {
                     let mut ary_iter = ary.into_iter();
                     Ok((
-                        A::from_resp(ary_iter.next().expect("No value"))?,
-                        B::from_resp(ary_iter.next().expect("No value"))?,
-                        C::from_resp(ary_iter.next().expect("No value"))?,
+                        A::try_from(ary_iter.next().expect("No value"))?,
+                        B::try_from(ary_iter.next().expect("No value"))?,
+                        C::try_from(ary_iter.next().expect("No value"))?,
                     ))
                 } else {
                     Err(Error::Resp(
@@ -344,9 +349,9 @@ where
                     ))
                 }
             }
-            _ => Err(error::resp(
+            other => Err(error::resp(
                 "Unexpected value, should be encoded as an array",
-                resp,
+                other,
             )),
         }
     }
@@ -743,7 +748,7 @@ mod tests {
 
     use tokio_util::codec::{Decoder, Encoder};
 
-    use super::{Error, FromResp, RespCodec, RespValue};
+    use super::{Error, RespCodec, RespValue};
 
     fn obj_to_bytes(obj: RespValue) -> Vec<u8> {
         let mut bytes = BytesMut::new();
@@ -815,21 +820,21 @@ mod tests {
     #[test]
     fn test_integer_overflow() {
         let resp_object = RespValue::Integer(i64::MAX);
-        let res = i32::from_resp(resp_object);
+        let res = i32::try_from(resp_object);
         assert!(res.is_err());
     }
 
     #[test]
     fn test_integer_underflow() {
         let resp_object = RespValue::Integer(-2);
-        let res = u64::from_resp(resp_object);
+        let res = u64::try_from(resp_object);
         assert!(res.is_err());
     }
 
     #[test]
     fn test_integer_convesion() {
         let resp_object = RespValue::Integer(50);
-        assert_eq!(u32::from_resp(resp_object).unwrap(), 50);
+        assert_eq!(u32::try_from(resp_object).unwrap(), 50);
     }
 
     #[test]
@@ -845,7 +850,7 @@ mod tests {
             "VALUE2".into(),
         ]);
         assert_eq!(
-            HashMap::<String, String>::from_resp(resp_object).unwrap(),
+            HashMap::<String, String>::try_from(resp_object).unwrap(),
             expected
         );
     }
@@ -859,7 +864,7 @@ mod tests {
             "VALUE2".into(),
             "KEY3".into(),
         ]);
-        let res = HashMap::<String, String>::from_resp(resp_object);
+        let res = HashMap::<String, String>::try_from(resp_object);
 
         match res {
             Err(Error::Resp(_, _)) => {}

--- a/src/resp.rs
+++ b/src/resp.rs
@@ -108,8 +108,6 @@ impl fmt::Debug for RespValue {
     }
 }
 
-
-
 impl TryFrom<RespValue> for String {
     type Error = Error;
 
@@ -241,7 +239,12 @@ impl<T: TryFrom<RespValue, Error = Error>> TryFrom<RespValue> for Vec<T> {
     }
 }
 
-impl<K: TryFrom<RespValue, Error = Error> + Hash + Eq, T: TryFrom<RespValue, Error = Error>, S: BuildHasher + Default> TryFrom<RespValue> for HashMap<K, T, S> {
+impl<
+        K: TryFrom<RespValue, Error = Error> + Hash + Eq,
+        T: TryFrom<RespValue, Error = Error>,
+        S: BuildHasher + Default,
+    > TryFrom<RespValue> for HashMap<K, T, S>
+{
     type Error = Error;
 
     #[inline]


### PR DESCRIPTION
Experimental: see what this looks like as an alternative.

This modernises half of the to/from RESP equation, but not the other half where custom traits are still required. It may be simpler to keep custom traits on both sides.