### PR TITLE
Align socket2 and tokio dependencies by upgrading tokio to 1.47

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,7 @@ log = "^0.4.11"
 native-tls = { version = "0.2", optional = true }
 pin-project = "1.0"
 socket2 = { version = "0.6.0", features = ["all"] }
-tokio = { version = "1.36", features = ["rt", "net", "time"] }
+tokio = { version = "1.47", features = ["rt", "net", "time"] }
 tokio-native-tls = { version = "0.3.0", optional = true }
 tokio-rustls = { version = "0.26", optional = true }
 tokio-util = { version = "0.7", features = ["codec"] }
@@ -33,4 +33,4 @@ with-native-tls = ["native-tls", "tokio-native-tls", "tls"]
 [dev-dependencies]
 env_logger = "0.11"
 futures = "^0.3.7"
-tokio = { version = "1.36", features = ["full"] }
+tokio = { version = "1.47", features = ["full"] }


### PR DESCRIPTION
1.47 being the minimum. Obviously that's quite old so we'd expect people to be on much newer versions, but it's semantically correct (as far as we can tell).